### PR TITLE
Fix the install-packages.sh script

### DIFF
--- a/cflinuxfs3/build/install-packages.sh
+++ b/cflinuxfs3/build/install-packages.sh
@@ -8,7 +8,7 @@ function apt_get() {
 
 packages="
 aptitude
-argon-dev
+libargon2-0-dev
 autoconf
 bison
 build-essential
@@ -23,7 +23,7 @@ flex
 fuse-emulator-utils
 gdb
 git-core
-gnupg-curl
+gnupg1-curl
 gsfonts
 imagemagick
 iputils-arping
@@ -32,17 +32,17 @@ krb5-user
 laptop-detect
 libaio1
 libatm1
-libavcodec54
-libboost-iostreams1.54.0:amd64
+libavcodec57
+libboost-iostreams1.62.0:amd64
 libcurl4-openssl-dev
-libcwidget3
-libdirectfb-1.2-9
+libcwidget3v5
+libdirectfb-1.7-7
 libdrm-intel1
 libdrm-nouveau2
 libdrm-radeon1
-libept1.4.12:amd64
+libept1.5.0:amd64
 libfuse-dev
-libgd2-noxpm-dev
+libgd-dev
 libgmp-dev
 libgpm2
 libgtk-3-0
@@ -59,11 +59,11 @@ libreadline6-dev
 libsasl2-dev
 libsasl2-modules
 libselinux1-dev
-libsigc++-2.0-0c2a:amd64
+libsigc++-2.0-0v5:amd64
 libsqlite0-dev
 libsqlite3-dev
 libsysfs2
-libxapian22
+libxapian30
 libxcb-render-util0
 libxslt1-dev
 libyaml-dev

--- a/cflinuxfs3/build/install-packages.sh
+++ b/cflinuxfs3/build/install-packages.sh
@@ -3,7 +3,7 @@ set -e -x
 source /etc/lsb-release
 
 function apt_get() {
-  apt-get -y --allow-downgrades --allow-remove-essential --allow-change-held-packages --no-install-recommends "$@"
+  DEBIAN_FRONTEND=noninteractive apt-get -y --allow-downgrades --allow-remove-essential --allow-change-held-packages --no-install-recommends "$@"
 }
 
 packages="

--- a/cflinuxfs3/build/install-packages.sh
+++ b/cflinuxfs3/build/install-packages.sh
@@ -3,7 +3,7 @@ set -e -x
 source /etc/lsb-release
 
 function apt_get() {
-  apt-get -y --force-yes --no-install-recommends "$@"
+  apt-get -y --allow-downgrades --allow-remove-essential --allow-change-held-packages --no-install-recommends "$@"
 }
 
 packages="

--- a/cflinuxfs3/cflinuxfs3_receipt
+++ b/cflinuxfs3/cflinuxfs3_receipt
@@ -3,591 +3,669 @@ Rootfs SHASUM: 70256540eb9730e146ebe4e6d7ca21394e71935b
 Desired=Unknown/Install/Remove/Purge/Hold
 | Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
 |/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
-||/ Name                               Version                                    Architecture Description
-+++-==================================-==========================================-============-===============================================================================
-ii  adduser                            3.113+nmu3ubuntu3                          all          add and remove users and groups
-ii  apt                                1.0.1ubuntu2.17                            amd64        commandline package manager
-ii  apt-utils                          1.0.1ubuntu2.17                            amd64        package management related utility programs
-ii  aptitude                           0.6.8.2-1ubuntu4                           amd64        terminal-based package manager
-ii  aptitude-common                    0.6.8.2-1ubuntu4                           all          architecture indepedent files for the aptitude package manager
-ii  autoconf                           2.69-6                                     all          automatic configure script builder
-ii  base-files                         7.2ubuntu5.5                               amd64        Debian base system miscellaneous files
-ii  base-passwd                        3.5.33                                     amd64        Debian base system master password and group files
-ii  bash                               4.3-7ubuntu1.7                             amd64        GNU Bourne Again SHell
-ii  bind9-host                         1:9.9.5.dfsg-3ubuntu0.16                   amd64        Version of 'host' bundled with BIND 9.X
-ii  binutils                           2.24-5ubuntu14.2                           amd64        GNU assembler, linker and binary utilities
-ii  bison                              2:3.0.2.dfsg-2                             amd64        YACC-compatible parser generator
-ii  bsdutils                           1:2.20.1-5.1ubuntu20.9                     amd64        Basic utilities from 4.4BSD-Lite
-ii  build-essential                    11.6ubuntu6                                amd64        Informational list of build-essential packages
-ii  busybox-initramfs                  1:1.21.0-1ubuntu1                          amd64        Standalone shell setup for initramfs
-ii  bzip2                              1.0.6-5                                    amd64        high-quality block-sorting file compressor - utilities
-ii  bzr                                2.6.0+bzr6593-1ubuntu1.6                   all          easy to use distributed version control system
-ii  ca-certificates                    20170717~14.04.1                           all          Common CA certificates
-ii  cmake                              2.8.12.2-0ubuntu3                          amd64        cross-platform, open-source make system
-ii  cmake-data                         2.8.12.2-0ubuntu3                          all          CMake data files (modules, templates and documentation)
-ii  comerr-dev                         2.1-1.42.9-3ubuntu1.3                      amd64        common error description library - headers and static libraries
-ii  console-setup                      1.70ubuntu8                                all          console font and keymap setup program
-ii  coreutils                          8.21-1ubuntu5.4                            amd64        GNU core utilities
-ii  cpio                               2.11+dfsg-1ubuntu1.2                       amd64        GNU cpio -- a program to manage archives of files
-ii  cpp                                4:4.8.2-1ubuntu6                           amd64        GNU C preprocessor (cpp)
-ii  cpp-4.8                            4.8.4-2ubuntu1~14.04.3                     amd64        GNU C preprocessor
-ii  cron                               3.0pl1-124ubuntu2                          amd64        process scheduling daemon
-ii  curl                               7.35.0-1ubuntu2.13                         amd64        command line tool for transferring data with URL syntax
-ii  dash                               0.5.7-4ubuntu1                             amd64        POSIX-compliant shell
-ii  dconf-gsettings-backend:amd64      0.20.0-1                                   amd64        simple configuration storage system - GSettings back-end
-ii  dconf-service                      0.20.0-1                                   amd64        simple configuration storage system - D-Bus service
-ii  debconf                            1.5.51ubuntu2                              all          Debian configuration management system
-ii  debconf-i18n                       1.5.51ubuntu2                              all          full internationalization support for debconf
-ii  debianutils                        4.4                                        amd64        Miscellaneous utilities specific to Debian
-ii  dh-python                          1.20140128-1ubuntu8.2                      all          Debian helper tools for packaging Python libraries and applications
-ii  diffutils                          1:3.3-1                                    amd64        File comparison utilities
-ii  dmidecode                          2.12-2                                     amd64        SMBIOS/DMI table decoder
-ii  dmsetup                            2:1.02.77-6ubuntu2                         amd64        Linux Kernel Device Mapper userspace library
-ii  dnsutils                           1:9.9.5.dfsg-3ubuntu0.16                   amd64        Clients provided with BIND
-ii  dpkg                               1.17.5ubuntu5.7                            amd64        Debian package management system
-ii  dpkg-dev                           1.17.5ubuntu5.7                            all          Debian package development tools
-ii  e2fslibs:amd64                     1.42.9-3ubuntu1.3                          amd64        ext2/ext3/ext4 file system libraries
-ii  e2fsprogs                          1.42.9-3ubuntu1.3                          amd64        ext2/ext3/ext4 file system utilities
-ii  eject                              2.1.5+deb1+cvs20081104-13.1ubuntu0.14.04.1 amd64        ejects CDs and operates CD-Changers under Linux
-ii  fakeroot                           1.20-3ubuntu2                              amd64        tool for simulating superuser privileges
-ii  file                               1:5.14-2ubuntu3.3                          amd64        Determines file type using "magic" numbers
-ii  findutils                          4.4.2-7                                    amd64        utilities for finding files--find, xargs
-ii  flex                               2.5.35-10.1ubuntu2                         amd64        A fast lexical analyzer generator.
-ii  fontconfig                         2.11.0-0ubuntu4.2                          amd64        generic font configuration library - support binaries
-ii  fontconfig-config                  2.11.0-0ubuntu4.2                          all          generic font configuration library - configuration
-ii  fonts-dejavu-core                  2.34-1ubuntu1                              all          Vera font family derivate with additional characters
-ii  fuse                               2.9.2-4ubuntu4.14.04.1                     amd64        Filesystem in Userspace
-ii  fuse-emulator-utils                1.1.1-1build1                              amd64        The Free Unix Spectrum Emulator - Utilities
-ii  g++                                4:4.8.2-1ubuntu6                           amd64        GNU C++ compiler
-ii  g++-4.8                            4.8.4-2ubuntu1~14.04.3                     amd64        GNU C++ compiler
-ii  gcc                                4:4.8.2-1ubuntu6                           amd64        GNU C compiler
-ii  gcc-4.8                            4.8.4-2ubuntu1~14.04.3                     amd64        GNU C compiler
-ii  gcc-4.8-base:amd64                 4.8.4-2ubuntu1~14.04.3                     amd64        GCC, the GNU Compiler Collection (base package)
-ii  gcc-4.9-base:amd64                 4.9.3-0ubuntu4                             amd64        GCC, the GNU Compiler Collection (base package)
-ii  gdb                                7.7.1-0ubuntu5~14.04.3                     amd64        GNU Debugger
-ii  gir1.2-freedesktop                 1.40.0-1ubuntu0.2                          amd64        Introspection data for some FreeDesktop components
-ii  gir1.2-gdkpixbuf-2.0               2.30.7-0ubuntu1.7                          amd64        GDK Pixbuf library - GObject-Introspection
-ii  gir1.2-glib-2.0                    1.40.0-1ubuntu0.2                          amd64        Introspection data for GLib, GObject, Gio and GModule
-ii  gir1.2-rsvg-2.0                    2.40.2-1                                   amd64        gir files for renderer library for SVG files
-ii  git                                1:1.9.1-1ubuntu0.7                         amd64        fast, scalable, distributed revision control system
-ii  git-core                           1:1.9.1-1ubuntu0.7                         all          fast, scalable, distributed revision control system (obsolete)
-ii  git-man                            1:1.9.1-1ubuntu0.7                         all          fast, scalable, distributed revision control system (manual pages)
-ii  gnupg                              1.4.16-1ubuntu2.4                          amd64        GNU privacy guard - a free PGP replacement
-ii  gnupg-curl                         1.4.16-1ubuntu2.4                          amd64        GNU privacy guard - a free PGP replacement (cURL)
-ii  gpgv                               1.4.16-1ubuntu2.4                          amd64        GNU privacy guard - signature verification tool
-ii  grep                               2.16-1                                     amd64        GNU grep, egrep and fgrep
-ii  gsfonts                            1:8.11+urwcyr1.0.7~pre44-4.2ubuntu1        all          Fonts for the Ghostscript interpreter(s)
-ii  gzip                               1.6-3ubuntu1                               amd64        GNU compression utilities
-ii  hicolor-icon-theme                 0.13-1                                     all          default fallback theme for FreeDesktop.org icon themes
-ii  hostname                           3.15ubuntu1                                amd64        utility to set/show the host name or domain name
-ii  icu-devtools                       52.1-3ubuntu0.7                            amd64        Development utilities for International Components for Unicode
-ii  ifupdown                           0.7.47.2ubuntu4.4                          amd64        high level tools to configure network interfaces
-ii  imagemagick                        8:6.7.7.10-6ubuntu3.9                      amd64        image manipulation programs
-ii  imagemagick-common                 8:6.7.7.10-6ubuntu3.9                      all          image manipulation programs -- infrastructure
-ii  init-system-helpers                1.14ubuntu1                                all          helper tools for all init systems
-ii  initramfs-tools                    0.103ubuntu4.9                             all          tools for generating an initramfs
-ii  initramfs-tools-bin                0.103ubuntu4.9                             amd64        binaries used by initramfs-tools
-ii  initscripts                        2.88dsf-41ubuntu6.3                        amd64        scripts for initializing and shutting down the system
-ii  insserv                            1.14.0-5ubuntu2                            amd64        boot sequence organizer using LSB init.d script dependency information
-ii  iproute2                           3.12.0-2ubuntu1.1                          amd64        networking and traffic control tools
-ii  iputils-arping                     3:20121221-4ubuntu1.1                      amd64        Tool to send ICMP echo requests to an ARP address
-ii  iputils-ping                       3:20121221-4ubuntu1.1                      amd64        Tools to test the reachability of network hosts
-ii  isc-dhcp-client                    4.2.4-7ubuntu12.10                         amd64        ISC DHCP client
-ii  isc-dhcp-common                    4.2.4-7ubuntu12.10                         amd64        common files used by all the isc-dhcp* packages
-ii  jq                                 1.3-1.1ubuntu1                             amd64        lightweight and flexible command-line JSON processor
-ii  kbd                                1.15.5-1ubuntu1                            amd64        Linux console font and keytable utilities
-ii  keyboard-configuration             1.70ubuntu8                                all          system-wide keyboard preferences
-ii  klibc-utils                        2.0.3-0ubuntu1.14.04.3                     amd64        small utilities built with klibc for early boot
-ii  kmod                               15-0ubuntu6                                amd64        tools for managing Linux kernel modules
-ii  krb5-config                        2.3                                        all          Configuration files for Kerberos Version 5
-ii  krb5-multidev                      1.12+dfsg-2ubuntu5.3                       amd64        Development files for MIT Kerberos without Heimdal conflict
-ii  krb5-user                          1.12+dfsg-2ubuntu5.3                       amd64        Basic programs to authenticate using MIT Kerberos
-ii  laptop-detect                      0.13.7ubuntu2                              amd64        attempt to detect a laptop
-ii  less                               458-2                                      amd64        pager program similar to more
-ii  libacl1:amd64                      2.2.52-1                                   amd64        Access control list shared library
-ii  libaio1:amd64                      0.3.109-4                                  amd64        Linux kernel AIO access library - shared library
-ii  libapr1:amd64                      1.5.0-1                                    amd64        Apache Portable Runtime Library
-ii  libaprutil1:amd64                  1.5.3-1                                    amd64        Apache Portable Runtime Utility Library
-ii  libapt-inst1.5:amd64               1.0.1ubuntu2.17                            amd64        deb package format runtime library
-ii  libapt-pkg4.12:amd64               1.0.1ubuntu2.17                            amd64        package management runtime library
-ii  libarchive-extract-perl            0.70-1                                     all          generic archive extracting module
-ii  libarchive13:amd64                 3.1.2-7ubuntu2.4                           amd64        Multi-format archive and compression library (shared library)
-ii  libasan0:amd64                     4.8.4-2ubuntu1~14.04.3                     amd64        AddressSanitizer -- a fast memory error detector
-ii  libasn1-8-heimdal:amd64            1.6~git20131207+dfsg-1ubuntu1.2            amd64        Heimdal Kerberos - ASN.1 library
-ii  libatk-bridge2.0-0:amd64           2.10.2-2ubuntu1                            amd64        AT-SPI 2 toolkit bridge - shared library
-ii  libatk1.0-0:amd64                  2.10.0-2ubuntu2                            amd64        ATK accessibility toolkit
-ii  libatk1.0-data                     2.10.0-2ubuntu2                            all          Common files for the ATK accessibility toolkit
-ii  libatm1:amd64                      1:2.5.1-1.5                                amd64        shared library for ATM (Asynchronous Transfer Mode)
-ii  libatomic1:amd64                   4.8.4-2ubuntu1~14.04.3                     amd64        support library providing __atomic built-in functions
-ii  libatspi2.0-0:amd64                2.10.2.is.2.10.1-0ubuntu1                  amd64        Assistive Technology Service Provider Interface - shared library
-ii  libattr1:amd64                     1:2.4.47-1ubuntu1                          amd64        Extended attribute shared library
-ii  libaudiofile1:amd64                0.3.6-2ubuntu0.14.04.2                     amd64        Open-source version of SGI's audiofile library
-ii  libaudit-common                    1:2.3.2-2ubuntu1                           all          Dynamic library for security auditing - common files
-ii  libaudit1:amd64                    1:2.3.2-2ubuntu1                           amd64        Dynamic library for security auditing
-ii  libavahi-client3:amd64             0.6.31-4ubuntu1.1                          amd64        Avahi client library
-ii  libavahi-common-data:amd64         0.6.31-4ubuntu1.1                          amd64        Avahi common data files
-ii  libavahi-common3:amd64             0.6.31-4ubuntu1.1                          amd64        Avahi common library
-ii  libavcodec54:amd64                 6:9.20-0ubuntu0.14.04.1                    amd64        Libav codec library
-ii  libavformat54:amd64                6:9.20-0ubuntu0.14.04.1                    amd64        Libav file format library
-ii  libavutil52:amd64                  6:9.20-0ubuntu0.14.04.1                    amd64        Libav utility library
-ii  libbind9-90                        1:9.9.5.dfsg-3ubuntu0.16                   amd64        BIND9 Shared Library used by BIND
-ii  libbison-dev:amd64                 2:3.0.2.dfsg-2                             amd64        YACC-compatible parser generator - development library
-ii  libblas-dev                        1.2.20110419-7                             amd64        Basic Linear Algebra Subroutines 3, static library
-ii  libblas3                           1.2.20110419-7                             amd64        Basic Linear Algebra Reference implementations, shared library
-ii  libblkid1:amd64                    2.20.1-5.1ubuntu20.9                       amd64        block device id library
-ii  libboost-iostreams1.54.0:amd64     1.54.0-4ubuntu3.1                          amd64        Boost.Iostreams Library
-ii  libbsd0:amd64                      0.6.0-2ubuntu1                             amd64        utility functions from BSD systems - shared library
-ii  libbz2-1.0:amd64                   1.0.6-5                                    amd64        high-quality block-sorting file compressor library - runtime
-ii  libbz2-dev:amd64                   1.0.6-5                                    amd64        high-quality block-sorting file compressor library - development
-ii  libc-bin                           2.19-0ubuntu6.13                           amd64        Embedded GNU C Library: Binaries
-ii  libc-dev-bin                       2.19-0ubuntu6.13                           amd64        Embedded GNU C Library: Development binaries
-ii  libc6:amd64                        2.19-0ubuntu6.13                           amd64        Embedded GNU C Library: Shared libraries
-ii  libc6-dev:amd64                    2.19-0ubuntu6.13                           amd64        Embedded GNU C Library: Development Libraries and Header Files
-ii  libcairo-gobject2:amd64            1.13.0~20140204-0ubuntu1.1                 amd64        The Cairo 2D vector graphics library (GObject library)
-ii  libcairo-script-interpreter2:amd64 1.13.0~20140204-0ubuntu1.1                 amd64        The Cairo 2D vector graphics library (script interpreter)
-ii  libcairo2:amd64                    1.13.0~20140204-0ubuntu1.1                 amd64        The Cairo 2D vector graphics library
-ii  libcairo2-dev                      1.13.0~20140204-0ubuntu1.1                 amd64        Development files for the Cairo 2D graphics library
-ii  libcap2:amd64                      1:2.24-0ubuntu2                            amd64        support for getting/setting POSIX.1e capabilities
-ii  libcap2-bin                        1:2.24-0ubuntu2                            amd64        basic utility programs for using capabilities
-ii  libcdt5                            2.36.0-0ubuntu3.2                          amd64        rich set of graph drawing tools - cdt library
-ii  libcgmanager0:amd64                0.24-0ubuntu7.5                            amd64        Central cgroup manager daemon (client library)
-ii  libcgraph6                         2.36.0-0ubuntu3.2                          amd64        rich set of graph drawing tools - cgraph library
-ii  libck-connector0:amd64             0.4.5-3.1ubuntu2                           amd64        ConsoleKit libraries
-ii  libclass-accessor-perl             0.34-1                                     all          Perl module that automatically generates accessors
-ii  libcloog-isl4:amd64                0.18.2-1                                   amd64        Chunky Loop Generator (runtime library)
-ii  libcolord1:amd64                   1.0.6-1                                    amd64        system service to manage device colour profiles -- runtime
-ii  libcomerr2:amd64                   1.42.9-3ubuntu1.3                          amd64        common error description library
-ii  libcroco3:amd64                    0.6.8-2ubuntu1                             amd64        Cascading Style Sheet (CSS) parsing and manipulation toolkit
-ii  libcups2:amd64                     1.7.2-0ubuntu1.8                           amd64        Common UNIX Printing System(tm) - Core library
-ii  libcurl3:amd64                     7.35.0-1ubuntu2.13                         amd64        easy-to-use client-side URL transfer library (OpenSSL flavour)
-ii  libcurl3-gnutls:amd64              7.35.0-1ubuntu2.13                         amd64        easy-to-use client-side URL transfer library (GnuTLS flavour)
-ii  libcurl4-openssl-dev:amd64         7.35.0-1ubuntu2.13                         amd64        development files and documentation for libcurl (OpenSSL flavour)
-ii  libcwidget3                        0.5.16-3.5ubuntu1                          amd64        high-level terminal interface library for C++ (runtime files)
-ii  libdatrie1:amd64                   0.2.8-1                                    amd64        Double-array trie library
-ii  libdb5.3:amd64                     5.3.28-3ubuntu3.1                          amd64        Berkeley v5.3 Database Libraries [runtime]
-ii  libdbus-1-3:amd64                  1.6.18-0ubuntu4.5                          amd64        simple interprocess messaging system (library)
-ii  libdconf1:amd64                    0.20.0-1                                   amd64        simple configuration storage system - runtime library
-ii  libdebconfclient0:amd64            0.187ubuntu1                               amd64        Debian Configuration Management System (C-implementation library)
-ii  libdevmapper1.02.1:amd64           2:1.02.77-6ubuntu2                         amd64        Linux Kernel Device Mapper userspace library
-ii  libdirectfb-1.2-9:amd64            1.2.10.0-5                                 amd64        direct frame buffer graphics - shared libraries
-ii  libdjvulibre-dev:amd64             3.5.25.4-3                                 amd64        Development files for the DjVu image format
-ii  libdjvulibre-text                  3.5.25.4-3                                 all          Linguistic support files for libdjvulibre
-ii  libdjvulibre21:amd64               3.5.25.4-3                                 amd64        Runtime support for the DjVu image format
-ii  libdns100                          1:9.9.5.dfsg-3ubuntu0.16                   amd64        DNS Shared Library used by BIND
-ii  libdpkg-perl                       1.17.5ubuntu5.7                            all          Dpkg perl modules
-ii  libdrm-intel1:amd64                2.4.67-1ubuntu0.14.04.2                    amd64        Userspace interface to intel-specific kernel DRM services -- runtime
-ii  libdrm-nouveau2:amd64              2.4.67-1ubuntu0.14.04.2                    amd64        Userspace interface to nouveau-specific kernel DRM services -- runtime
-ii  libdrm-radeon1:amd64               2.4.67-1ubuntu0.14.04.2                    amd64        Userspace interface to radeon-specific kernel DRM services -- runtime
-ii  libdrm2:amd64                      2.4.67-1ubuntu0.14.04.2                    amd64        Userspace interface to kernel DRM services -- runtime
-ii  libedit2:amd64                     3.1-20130712-2                             amd64        BSD editline and history libraries
-ii  libelfg0:amd64                     0.8.13-5                                   amd64        an ELF object file access library
-ii  libept1.4.12:amd64                 1.0.12                                     amd64        High-level library for managing Debian package information
-ii  liberror-perl                      0.17-1.1                                   all          Perl module for error/exception handling in an OO-ish way
-ii  libestr0                           0.1.9-0ubuntu2                             amd64        Helper functions for handling strings (lib)
-ii  libexif-dev                        0.6.21-1ubuntu1                            amd64        library to parse EXIF files (development files)
-ii  libexif12:amd64                    0.6.21-1ubuntu1                            amd64        library to parse EXIF files
-ii  libexpat1:amd64                    2.1.0-4ubuntu1.4                           amd64        XML parsing C library - runtime library
-ii  libexpat1-dev:amd64                2.1.0-4ubuntu1.4                           amd64        XML parsing C library - development kit
-ii  libfakeroot:amd64                  1.20-3ubuntu2                              amd64        tool for simulating superuser privileges - shared libraries
-ii  libffi6:amd64                      3.1~rc1+r3.0.13-12ubuntu0.2                amd64        Foreign Function Interface library runtime
-ii  libfftw3-double3:amd64             3.3.3-7ubuntu3                             amd64        Library for computing Fast Fourier Transforms - Double precision
-ii  libfl-dev:amd64                    2.5.35-10.1ubuntu2                         amd64        static library for flex (a fast lexical analyzer generator).
-ii  libflac8:amd64                     1.3.0-2ubuntu0.14.04.1                     amd64        Free Lossless Audio Codec - runtime C library
-ii  libfontconfig1:amd64               2.11.0-0ubuntu4.2                          amd64        generic font configuration library - runtime
-ii  libfontconfig1-dev                 2.11.0-0ubuntu4.2                          amd64        generic font configuration library - development
-ii  libfreetype6:amd64                 2.5.2-1ubuntu2.8                           amd64        FreeType 2 font engine, shared library files
-ii  libfreetype6-dev                   2.5.2-1ubuntu2.8                           amd64        FreeType 2 font engine, development files
-ii  libfribidi0:amd64                  0.19.6-1                                   amd64        Free Implementation of the Unicode BiDi algorithm
-ii  libfuse-dev                        2.9.2-4ubuntu4.14.04.1                     amd64        Filesystem in Userspace (development)
-ii  libfuse2:amd64                     2.9.2-4ubuntu4.14.04.1                     amd64        Filesystem in Userspace (library)
-ii  libgcc-4.8-dev:amd64               4.8.4-2ubuntu1~14.04.3                     amd64        GCC support library (development files)
-ii  libgcc1:amd64                      1:4.9.3-0ubuntu4                           amd64        GCC support library
-ii  libgcrypt11:amd64                  1.5.3-2ubuntu4.5                           amd64        LGPL Crypto library - runtime library
-ii  libgcrypt11-dev                    1.5.3-2ubuntu4.5                           amd64        LGPL Crypto library - development files
-ii  libgd-dev:amd64                    2.1.0-3ubuntu0.8                           amd64        GD Graphics Library (development version)
-ii  libgd2-noxpm-dev                   2.1.0-3ubuntu0.8                           all          GD Graphics Library (transitional package)
-ii  libgd3:amd64                       2.1.0-3ubuntu0.8                           amd64        GD Graphics Library
-ii  libgdbm3:amd64                     1.8.3-12build1                             amd64        GNU dbm database routines (runtime version)
-ii  libgdk-pixbuf2.0-0:amd64           2.30.7-0ubuntu1.7                          amd64        GDK Pixbuf library
-ii  libgdk-pixbuf2.0-common            2.30.7-0ubuntu1.7                          all          GDK Pixbuf library - data files
-ii  libgdk-pixbuf2.0-dev               2.30.7-0ubuntu1.7                          amd64        GDK Pixbuf library (development files)
-ii  libgeoip1:amd64                    1.6.0-1                                    amd64        non-DNS IP-to-country resolver library
-ii  libgfortran3:amd64                 4.8.4-2ubuntu1~14.04.3                     amd64        Runtime library for GNU Fortran applications
-ii  libgirepository-1.0-1              1.40.0-1ubuntu0.2                          amd64        Library for handling GObject introspection data (runtime library)
-ii  libglib2.0-0:amd64                 2.40.2-0ubuntu1                            amd64        GLib library of C routines
-ii  libglib2.0-bin                     2.40.2-0ubuntu1                            amd64        Programs for the GLib library
-ii  libglib2.0-data                    2.40.2-0ubuntu1                            all          Common files for GLib library
-ii  libglib2.0-dev                     2.40.2-0ubuntu1                            amd64        Development files for the GLib library
-ii  libgmp-dev:amd64                   2:5.1.3+dfsg-1ubuntu1                      amd64        Multiprecision arithmetic library developers tools
-ii  libgmp10:amd64                     2:5.1.3+dfsg-1ubuntu1                      amd64        Multiprecision arithmetic library
-ii  libgmpxx4ldbl:amd64                2:5.1.3+dfsg-1ubuntu1                      amd64        Multiprecision arithmetic library (C++ bindings)
-ii  libgnutls-dev                      2.12.23-12ubuntu2.8                        amd64        GNU TLS library - development files
-ii  libgnutls-openssl27:amd64          2.12.23-12ubuntu2.8                        amd64        GNU TLS library - OpenSSL wrapper
-ii  libgnutls26:amd64                  2.12.23-12ubuntu2.8                        amd64        GNU TLS library - runtime library
-ii  libgnutlsxx27:amd64                2.12.23-12ubuntu2.8                        amd64        GNU TLS library - C++ runtime library
-ii  libgomp1:amd64                     4.8.4-2ubuntu1~14.04.3                     amd64        GCC OpenMP (GOMP) support library
-ii  libgpg-error-dev                   1.12-0.2ubuntu1                            amd64        library for common error values and messages in GnuPG components (development)
-ii  libgpg-error0:amd64                1.12-0.2ubuntu1                            amd64        library for common error values and messages in GnuPG components
-ii  libgpm2:amd64                      1.20.4-6.1                                 amd64        General Purpose Mouse - shared library
-ii  libgraphite2-3:amd64               1.3.10-0ubuntu0.14.04.1                    amd64        Font rendering engine for Complex Scripts -- library
-ii  libgraphviz-dev                    2.36.0-0ubuntu3.2                          amd64        graphviz libs and headers against which to build applications
-ii  libgsm1:amd64                      1.0.13-4                                   amd64        Shared libraries for GSM speech compressor
-ii  libgssapi-krb5-2:amd64             1.12+dfsg-2ubuntu5.3                       amd64        MIT Kerberos runtime libraries - krb5 GSS-API Mechanism
-ii  libgssapi3-heimdal:amd64           1.6~git20131207+dfsg-1ubuntu1.2            amd64        Heimdal Kerberos - GSSAPI support library
-ii  libgssrpc4:amd64                   1.12+dfsg-2ubuntu5.3                       amd64        MIT Kerberos runtime libraries - GSS enabled ONCRPC
-ii  libgtk-3-0:amd64                   3.10.8-0ubuntu1.6                          amd64        GTK+ graphical user interface library
-ii  libgtk-3-common                    3.10.8-0ubuntu1.6                          all          common files for the GTK+ graphical user interface library
-ii  libgtk2.0-0:amd64                  2.24.23-0ubuntu1.4                         amd64        GTK+ graphical user interface library
-ii  libgtk2.0-common                   2.24.23-0ubuntu1.4                         all          common files for the GTK+ graphical user interface library
-ii  libgvc6                            2.36.0-0ubuntu3.2                          amd64        rich set of graph drawing tools - gvc library
-ii  libgvc6-plugins-gtk                2.36.0-0ubuntu3.2                          amd64        rich set of graph drawing tools - gtk plugins
-ii  libgvpr2                           2.36.0-0ubuntu3.2                          amd64        rich set of graph drawing tools - gvpr library
-ii  libharfbuzz0b:amd64                0.9.27-1ubuntu1.1                          amd64        OpenType text shaping engine (shared library)
-ii  libhcrypto4-heimdal:amd64          1.6~git20131207+dfsg-1ubuntu1.2            amd64        Heimdal Kerberos - crypto library
-ii  libheimbase1-heimdal:amd64         1.6~git20131207+dfsg-1ubuntu1.2            amd64        Heimdal Kerberos - Base library
-ii  libheimntlm0-heimdal:amd64         1.6~git20131207+dfsg-1ubuntu1.2            amd64        Heimdal Kerberos - NTLM support library
-ii  libhx509-5-heimdal:amd64           1.6~git20131207+dfsg-1ubuntu1.2            amd64        Heimdal Kerberos - X509 support library
-ii  libice-dev:amd64                   2:1.0.8-2                                  amd64        X11 Inter-Client Exchange library (development headers)
-ii  libice6:amd64                      2:1.0.8-2                                  amd64        X11 Inter-Client Exchange library
-ii  libicu-dev:amd64                   52.1-3ubuntu0.7                            amd64        Development files for International Components for Unicode
-ii  libicu52:amd64                     52.1-3ubuntu0.7                            amd64        International Components for Unicode
-ii  libidn11:amd64                     1.28-1ubuntu2.2                            amd64        GNU Libidn library, implementation of IETF IDN specifications
-ii  libidn11-dev                       1.28-1ubuntu2.2                            amd64        Development files for GNU Libidn, an IDN library
-ii  libilmbase-dev                     1.0.1-6ubuntu1                             amd64        development files for IlmBase
-ii  libilmbase6:amd64                  1.0.1-6ubuntu1                             amd64        several utility libraries from ILM used by OpenEXR
-ii  libio-string-perl                  1.08-3                                     all          Emulate IO::File interface for in-core strings
-ii  libisc95                           1:9.9.5.dfsg-3ubuntu0.16                   amd64        ISC Shared Library used by BIND
-ii  libisccc90                         1:9.9.5.dfsg-3ubuntu0.16                   amd64        Command Channel Library used by BIND
-ii  libisccfg90                        1:9.9.5.dfsg-3ubuntu0.16                   amd64        Config File Handling Library used by BIND
-ii  libisl10:amd64                     0.12.2-1                                   amd64        manipulating sets and relations of integer points bounded by linear constraints
-ii  libitm1:amd64                      4.8.4-2ubuntu1~14.04.3                     amd64        GNU Transactional Memory Library
-ii  libjasper-dev                      1.900.1-14ubuntu3.4                        amd64        Development files for the JasPer JPEG-2000 library
-ii  libjasper1:amd64                   1.900.1-14ubuntu3.4                        amd64        JasPer JPEG-2000 runtime library
-ii  libjbig-dev:amd64                  2.0-2ubuntu4.1                             amd64        JBIGkit development files
-ii  libjbig0:amd64                     2.0-2ubuntu4.1                             amd64        JBIGkit libraries
-ii  libjpeg-dev:amd64                  8c-2ubuntu8                                amd64        Independent JPEG Group's JPEG runtime library (dependency package)
-ii  libjpeg-turbo8:amd64               1.3.0-0ubuntu2                             amd64        IJG JPEG compliant runtime library.
-ii  libjpeg-turbo8-dev:amd64           1.3.0-0ubuntu2                             amd64        Development files for the IJG JPEG library
-ii  libjpeg8:amd64                     8c-2ubuntu8                                amd64        Independent JPEG Group's JPEG runtime library (dependency package)
-ii  libjpeg8-dev:amd64                 8c-2ubuntu8                                amd64        Independent JPEG Group's JPEG runtime library (dependency package)
-ii  libjs-jquery                       1.7.2+dfsg-2ubuntu1                        all          JavaScript library for dynamic web applications
-ii  libjson-c2:amd64                   0.11-3ubuntu1.2                            amd64        JSON manipulation library - shared library
-ii  libjson0:amd64                     0.11-3ubuntu1.2                            amd64        JSON manipulation library (transitional package)
-ii  libk5crypto3:amd64                 1.12+dfsg-2ubuntu5.3                       amd64        MIT Kerberos runtime libraries - Crypto Library
-ii  libkadm5clnt-mit9:amd64            1.12+dfsg-2ubuntu5.3                       amd64        MIT Kerberos runtime libraries - Administration Clients
-ii  libkadm5srv-mit9:amd64             1.12+dfsg-2ubuntu5.3                       amd64        MIT Kerberos runtime libraries - KDC and Admin Server
-ii  libkdb5-7:amd64                    1.12+dfsg-2ubuntu5.3                       amd64        MIT Kerberos runtime libraries - Kerberos database
-ii  libkeyutils1:amd64                 1.5.6-1                                    amd64        Linux Key Management Utilities (library)
-ii  libklibc                           2.0.3-0ubuntu1.14.04.3                     amd64        minimal libc subset for use with initramfs
-ii  libkmod2:amd64                     15-0ubuntu6                                amd64        libkmod shared library
-ii  libkrb5-26-heimdal:amd64           1.6~git20131207+dfsg-1ubuntu1.2            amd64        Heimdal Kerberos - libraries
-ii  libkrb5-3:amd64                    1.12+dfsg-2ubuntu5.3                       amd64        MIT Kerberos runtime libraries
-ii  libkrb5-dev                        1.12+dfsg-2ubuntu5.3                       amd64        Headers and development libraries for MIT Kerberos
-ii  libkrb5support0:amd64              1.12+dfsg-2ubuntu5.3                       amd64        MIT Kerberos runtime libraries - Support library
-ii  liblapack-dev                      3.5.0-2ubuntu1                             amd64        Library of linear algebra routines 3 - static version
-ii  liblapack3                         3.5.0-2ubuntu1                             amd64        Library of linear algebra routines 3 - shared version
-ii  liblcms2-2:amd64                   2.5-0ubuntu4.1                             amd64        Little CMS 2 color management library
-ii  liblcms2-dev:amd64                 2.5-0ubuntu4.1                             amd64        Little CMS 2 color management library development headers
-ii  libldap-2.4-2:amd64                2.4.31-1+nmu2ubuntu8.4                     amd64        OpenLDAP libraries
-ii  libldap2-dev:amd64                 2.4.31-1+nmu2ubuntu8.4                     amd64        OpenLDAP development libraries
-ii  liblocale-gettext-perl             1.05-7build3                               amd64        module using libc functions for internationalization in Perl
-ii  liblockfile-bin                    1.09-6ubuntu1                              amd64        support binaries for and cli utilities based on liblockfile
-ii  liblockfile1:amd64                 1.09-6ubuntu1                              amd64        NFS-safe locking library
-ii  liblog-message-simple-perl         0.10-1                                     all          simplified interface to Log::Message
-ii  liblqr-1-0:amd64                   0.4.1-2ubuntu1                             amd64        converts plain array images into multi-size representation
-ii  liblqr-1-0-dev                     0.4.1-2ubuntu1                             amd64        converts plain array images into multi-size representation (developments files)
-ii  libltdl-dev:amd64                  2.4.2-1.7ubuntu1                           amd64        A system independent dlopen wrapper for GNU libtool
-ii  libltdl7:amd64                     2.4.2-1.7ubuntu1                           amd64        A system independent dlopen wrapper for GNU libtool
-ii  liblwres90                         1:9.9.5.dfsg-3ubuntu0.16                   amd64        Lightweight Resolver Library used by BIND
-ii  liblzma-dev:amd64                  5.1.1alpha+20120614-2ubuntu2               amd64        XZ-format compression library - development files
-ii  liblzma5:amd64                     5.1.1alpha+20120614-2ubuntu2               amd64        XZ-format compression library
-ii  liblzo2-2:amd64                    2.06-1.2ubuntu1.1                          amd64        data compression library
-ii  libmagic1:amd64                    1:5.14-2ubuntu3.3                          amd64        File type determination library using "magic" numbers
-ii  libmagickcore-dev                  8:6.7.7.10-6ubuntu3.9                      amd64        low-level image manipulation library - development files
-ii  libmagickcore5:amd64               8:6.7.7.10-6ubuntu3.9                      amd64        low-level image manipulation library
-ii  libmagickcore5-extra:amd64         8:6.7.7.10-6ubuntu3.9                      amd64        low-level image manipulation library - extra codecs
-ii  libmagickwand-dev                  8:6.7.7.10-6ubuntu3.9                      amd64        image manipulation library - development files
-ii  libmagickwand5:amd64               8:6.7.7.10-6ubuntu3.9                      amd64        image manipulation library
-ii  libmariadbclient-dev               5.5.57-1ubuntu0.14.04.1                    amd64        MariaDB database development files
-ii  libmariadbclient18:amd64           5.5.57-1ubuntu0.14.04.1                    amd64        MariaDB database client library
-ii  libmodule-pluggable-perl           5.1-1                                      all          module for giving  modules the ability to have plugins
-ii  libmount1:amd64                    2.20.1-5.1ubuntu20.9                       amd64        block device id library
-ii  libmp3lame0:amd64                  3.99.5+repack1-3ubuntu1                    amd64        MP3 encoding library
-ii  libmpc3:amd64                      1.0.1-1ubuntu1                             amd64        multiple precision complex floating-point library
-ii  libmpdec2:amd64                    2.4.0-6                                    amd64        library for decimal floating point arithmetic (runtime library)
-ii  libmpfr4:amd64                     3.1.2-1                                    amd64        multiple precision floating-point computation
-rc  libmysqlclient18:amd64             5.5.58-0ubuntu0.14.04.1                    amd64        MySQL database client library
-ii  libncurses5:amd64                  5.9+20140118-1ubuntu1                      amd64        shared libraries for terminal handling
-ii  libncurses5-dev:amd64              5.9+20140118-1ubuntu1                      amd64        developer's libraries for ncurses
-ii  libncursesw5:amd64                 5.9+20140118-1ubuntu1                      amd64        shared libraries for terminal handling (wide character support)
-ii  libnettle4:amd64                   2.7.1-1ubuntu0.2                           amd64        low level cryptographic library (symmetric and one-way cryptos)
-ii  libnewt0.52:amd64                  0.52.15-2ubuntu5                           amd64        Not Erik's Windowing Toolkit - text mode windowing with slang
-ii  libnih-dbus1:amd64                 1.0.3-4ubuntu25                            amd64        NIH D-Bus Bindings Library
-ii  libnih1:amd64                      1.0.3-4ubuntu25                            amd64        NIH Utility Library
-ii  libnl-3-200:amd64                  3.2.21-1ubuntu4.1                          amd64        library for dealing with netlink sockets
-ii  libnl-genl-3-200:amd64             3.2.21-1ubuntu4.1                          amd64        library for dealing with netlink sockets - generic netlink
-ii  libogg0:amd64                      1.3.1-1ubuntu1                             amd64        Ogg bitstream library
-ii  libopenblas-base                   0.2.8-6ubuntu1                             amd64        Optimized BLAS (linear algebra) library based on GotoBLAS2
-ii  libopenblas-dev                    0.2.8-6ubuntu1                             amd64        Optimized BLAS (linear algebra) library based on GotoBLAS2
-ii  libopenexr-dev                     1.6.1-7ubuntu1                             amd64        development files for the OpenEXR image library
-ii  libopenexr6:amd64                  1.6.1-7ubuntu1                             amd64        runtime files for the OpenEXR image library
-ii  libopenjpeg2:amd64                 1.3+dfsg-4.7ubuntu1                        amd64        JPEG 2000 image compression/decompression library
-ii  libopus0                           1.1-0ubuntu1                               amd64        Opus codec runtime library
-ii  liborc-0.4-0:amd64                 1:0.4.18-1ubuntu1                          amd64        Library of Optimized Inner Loops Runtime Compiler
-ii  libp11-kit-dev                     0.20.2-2ubuntu2                            amd64        Library for loading and coordinating access to PKCS#11 modules - development
-ii  libp11-kit0:amd64                  0.20.2-2ubuntu2                            amd64        Library for loading and coordinating access to PKCS#11 modules - runtime
-ii  libpam-cap:amd64                   1:2.24-0ubuntu2                            amd64        PAM module for implementing capabilities
-ii  libpam-modules:amd64               1.1.8-1ubuntu2.2                           amd64        Pluggable Authentication Modules for PAM
-ii  libpam-modules-bin                 1.1.8-1ubuntu2.2                           amd64        Pluggable Authentication Modules for PAM - helper binaries
-ii  libpam-runtime                     1.1.8-1ubuntu2.2                           all          Runtime support for the PAM library
-ii  libpam0g:amd64                     1.1.8-1ubuntu2.2                           amd64        Pluggable Authentication Modules library
-ii  libpango-1.0-0:amd64               1.36.3-1ubuntu1.1                          amd64        Layout and rendering of internationalized text
-ii  libpango1.0-0:amd64                1.36.3-1ubuntu1.1                          amd64        Layout and rendering of internationalized text
-ii  libpangocairo-1.0-0:amd64          1.36.3-1ubuntu1.1                          amd64        Layout and rendering of internationalized text
-ii  libpangoft2-1.0-0:amd64            1.36.3-1ubuntu1.1                          amd64        Layout and rendering of internationalized text
-ii  libpangox-1.0-0:amd64              0.0.2-4ubuntu1                             amd64        pango library X backend
-ii  libpangoxft-1.0-0:amd64            1.36.3-1ubuntu1.1                          amd64        Layout and rendering of internationalized text
-ii  libparse-debianchangelog-perl      1.2.0-1ubuntu1                             all          parse Debian changelogs and output them in other formats
-ii  libpathplan4                       2.36.0-0ubuntu3.2                          amd64        rich set of graph drawing tools - pathplan library
-ii  libpcap0.8:amd64                   1.5.3-2                                    amd64        system interface for user-level packet capture
-ii  libpciaccess0:amd64                0.13.2-1                                   amd64        Generic PCI access library for X
-ii  libpcre3:amd64                     1:8.31-2ubuntu2.3                          amd64        Perl 5 Compatible Regular Expression Library - runtime files
-ii  libpcre3-dev:amd64                 1:8.31-2ubuntu2.3                          amd64        Perl 5 Compatible Regular Expression Library - development files
-ii  libpcrecpp0:amd64                  1:8.31-2ubuntu2.3                          amd64        Perl 5 Compatible Regular Expression Library - C++ runtime files
-ii  libpixman-1-0:amd64                0.30.2-2ubuntu1.1                          amd64        pixel-manipulation library for X and cairo
-ii  libpixman-1-dev                    0.30.2-2ubuntu1.1                          amd64        pixel-manipulation library for X and cairo (development files)
-ii  libplymouth2:amd64                 0.8.8-0ubuntu17.1                          amd64        graphical boot animation and logger - shared libraries
-ii  libpng12-0:amd64                   1.2.50-1ubuntu2.14.04.2                    amd64        PNG library - runtime
-ii  libpng12-dev                       1.2.50-1ubuntu2.14.04.2                    amd64        PNG library - development
-ii  libpod-latex-perl                  0.61-1                                     all          module to convert Pod data to formatted LaTeX
-ii  libpopt0:amd64                     1.16-8ubuntu1                              amd64        lib for parsing cmdline parameters
-ii  libpq-dev                          9.3.20-0ubuntu0.14.04                      amd64        header files for libpq5 (PostgreSQL library)
-ii  libpq5                             9.3.20-0ubuntu0.14.04                      amd64        PostgreSQL C client library
-ii  libprocps3:amd64                   1:3.3.9-1ubuntu2.2                         amd64        library for accessing process information from /proc
-ii  libpthread-stubs0-dev:amd64        0.3-4                                      amd64        pthread stubs not provided by native libc, development files
-ii  libpython-stdlib:amd64             2.7.5-5ubuntu3                             amd64        interactive high-level object-oriented language (default python version)
-ii  libpython2.7-minimal:amd64         2.7.6-8ubuntu0.4                           amd64        Minimal subset of the Python language (version 2.7)
-ii  libpython2.7-stdlib:amd64          2.7.6-8ubuntu0.4                           amd64        Interactive high-level object-oriented language (standard library, version 2.7)
-ii  libpython3-stdlib:amd64            3.4.0-0ubuntu2                             amd64        interactive high-level object-oriented language (default python3 version)
-ii  libpython3.4:amd64                 3.4.3-1ubuntu1~14.04.6                     amd64        Shared Python runtime library (version 3.4)
-ii  libpython3.4-minimal:amd64         3.4.3-1ubuntu1~14.04.6                     amd64        Minimal subset of the Python language (version 3.4)
-ii  libpython3.4-stdlib:amd64          3.4.3-1ubuntu1~14.04.6                     amd64        Interactive high-level object-oriented language (standard library, version 3.4)
-ii  libquadmath0:amd64                 4.8.4-2ubuntu1~14.04.3                     amd64        GCC Quad-Precision Math Library
-ii  libreadline6:amd64                 6.3-4ubuntu2                               amd64        GNU readline and history libraries, run-time libraries
-ii  libreadline6-dev:amd64             6.3-4ubuntu2                               amd64        GNU readline and history libraries, development files
-ii  libroken18-heimdal:amd64           1.6~git20131207+dfsg-1ubuntu1.2            amd64        Heimdal Kerberos - roken support library
-ii  librsvg2-2:amd64                   2.40.2-1                                   amd64        SAX-based renderer library for SVG files (runtime)
-ii  librsvg2-common:amd64              2.40.2-1                                   amd64        SAX-based renderer library for SVG files (extra runtime)
-ii  librsvg2-dev                       2.40.2-1                                   amd64        SAX-based renderer library for SVG files (development)
-ii  librtmp-dev                        2.4+20121230.gitdf6c518-1ubuntu0.1         amd64        toolkit for RTMP streams (development files)
-ii  librtmp0:amd64                     2.4+20121230.gitdf6c518-1ubuntu0.1         amd64        toolkit for RTMP streams (shared library)
-ii  libsasl2-2:amd64                   2.1.25.dfsg1-17build1                      amd64        Cyrus SASL - authentication abstraction library
-ii  libsasl2-dev                       2.1.25.dfsg1-17build1                      amd64        Cyrus SASL - development files for authentication abstraction library
-ii  libsasl2-modules:amd64             2.1.25.dfsg1-17build1                      amd64        Cyrus SASL - pluggable authentication modules
-ii  libsasl2-modules-db:amd64          2.1.25.dfsg1-17build1                      amd64        Cyrus SASL - pluggable authentication modules (DB)
-ii  libschroedinger-1.0-0:amd64        1.0.11-2ubuntu1                            amd64        library for encoding/decoding of Dirac video streams
-ii  libselinux1:amd64                  2.2.2-1ubuntu0.1                           amd64        SELinux runtime shared libraries
-ii  libselinux1-dev:amd64              2.2.2-1ubuntu0.1                           amd64        SELinux development headers
-ii  libsemanage-common                 2.2-1                                      all          Common files for SELinux policy management libraries
-ii  libsemanage1:amd64                 2.2-1                                      amd64        SELinux policy management library
-ii  libsensors4:amd64                  1:3.3.4-2ubuntu1                           amd64        library to read temperature/voltage/fan sensors
-ii  libsepol1:amd64                    2.2-1ubuntu0.1                             amd64        SELinux library for manipulating binary security policies
-ii  libsepol1-dev                      2.2-1ubuntu0.1                             amd64        SELinux binary policy manipulation library and development files
-ii  libserf-1-1:amd64                  1.3.3-1ubuntu0.1                           amd64        high-performance asynchronous HTTP client library
-ii  libsigc++-2.0-0c2a:amd64           2.2.10-0.2ubuntu2                          amd64        type-safe Signal Framework for C++ - runtime
-ii  libsigsegv2:amd64                  2.10-2                                     amd64        Library for handling page faults in a portable way
-ii  libslang2:amd64                    2.2.4-15ubuntu1                            amd64        S-Lang programming library - runtime version
-ii  libsm-dev:amd64                    2:1.2.1-2                                  amd64        X11 Session Management library (development headers)
-ii  libsm6:amd64                       2:1.2.1-2                                  amd64        X11 Session Management library
-ii  libspectrum8:amd64                 1.1.1-1                                    amd64        ZX Spectrum emulator library - Shared libraries
-ii  libspeex1:amd64                    1.2~rc1.1-1ubuntu1                         amd64        The Speex codec runtime library
-ii  libsqlite0                         2.8.17-10ubuntu2                           amd64        SQLite shared library
-ii  libsqlite0-dev                     2.8.17-10ubuntu2                           amd64        SQLite development files
-ii  libsqlite3-0:amd64                 3.8.2-1ubuntu2.1                           amd64        SQLite 3 shared library
-ii  libsqlite3-dev:amd64               3.8.2-1ubuntu2.1                           amd64        SQLite 3 development files
-ii  libss2:amd64                       1.42.9-3ubuntu1.3                          amd64        command-line interface parsing library
-ii  libssl-dev:amd64                   1.0.1f-1ubuntu2.23                         amd64        Secure Sockets Layer toolkit - development files
-ii  libssl1.0.0:amd64                  1.0.1f-1ubuntu2.23                         amd64        Secure Sockets Layer toolkit - shared libraries
-ii  libstdc++-4.8-dev:amd64            4.8.4-2ubuntu1~14.04.3                     amd64        GNU Standard C++ Library v3 (development files)
-ii  libstdc++6:amd64                   4.8.4-2ubuntu1~14.04.3                     amd64        GNU Standard C++ Library v3
-ii  libsub-name-perl                   0.05-1build4                               amd64        module for assigning a new name to referenced sub
-ii  libsvn1:amd64                      1.8.8-1ubuntu3.3                           amd64        Shared libraries used by Apache Subversion
-ii  libswscale2:amd64                  6:9.20-0ubuntu0.14.04.1                    amd64        Libav video scaling library
-ii  libsysfs2:amd64                    2.1.0+repack-3ubuntu1                      amd64        interface library to sysfs
-ii  libtasn1-6:amd64                   3.4-3ubuntu0.5                             amd64        Manage ASN.1 structures (runtime)
-ii  libtasn1-6-dev                     3.4-3ubuntu0.5                             amd64        Manage ASN.1 structures (development)
-ii  libterm-ui-perl                    0.42-1                                     all          Term::ReadLine UI made easy
-ii  libtext-charwidth-perl             0.04-7build3                               amd64        get display widths of characters on the terminal
-ii  libtext-iconv-perl                 1.7-5build2                                amd64        converts between character sets in Perl
-ii  libtext-soundex-perl               3.4-1build1                                amd64        implementation of the soundex algorithm
-ii  libtext-wrapi18n-perl              0.06-7                                     all          internationalized substitute of Text::Wrap
-ii  libthai-data                       0.1.20-3                                   all          Data files for Thai language support library
-ii  libthai0:amd64                     0.1.20-3                                   amd64        Thai language support library
-ii  libtheora0:amd64                   1.1.1+dfsg.1-3.2                           amd64        Theora Video Compression Codec
-ii  libtiff5:amd64                     4.0.3-7ubuntu0.7                           amd64        Tag Image File Format (TIFF) library
-ii  libtiff5-dev:amd64                 4.0.3-7ubuntu0.7                           amd64        Tag Image File Format library (TIFF), development files
-ii  libtiffxx5:amd64                   4.0.3-7ubuntu0.7                           amd64        Tag Image File Format (TIFF) library -- C++ interface
-ii  libtimedate-perl                   2.3000-1                                   all          collection of modules to manipulate date/time information
-ii  libtinfo-dev:amd64                 5.9+20140118-1ubuntu1                      amd64        developer's library for the low-level terminfo library
-ii  libtinfo5:amd64                    5.9+20140118-1ubuntu1                      amd64        shared low-level terminfo library for terminal handling
-ii  libts-0.0-0:amd64                  1.0-12                                     amd64        touch screen library
-ii  libtsan0:amd64                     4.8.4-2ubuntu1~14.04.3                     amd64        ThreadSanitizer -- a Valgrind-based detector of data races (runtime)
-ii  libudev1:amd64                     204-5ubuntu20.25                           amd64        libudev shared library
-ii  libusb-0.1-4:amd64                 2:0.1.12-23.3ubuntu1                       amd64        userspace USB programming library
-ii  libustr-1.0-1:amd64                1.0.4-3ubuntu2                             amd64        Micro string library: shared library
-ii  libuuid1:amd64                     2.20.1-5.1ubuntu20.9                       amd64        Universally Unique ID library
-ii  libva1:amd64                       1.3.0-2                                    amd64        Video Acceleration (VA) API for Linux -- runtime
-ii  libvorbis0a:amd64                  1.3.2-1.3ubuntu1                           amd64        The Vorbis General Audio Compression Codec (Decoder library)
-ii  libvorbisenc2:amd64                1.3.2-1.3ubuntu1                           amd64        The Vorbis General Audio Compression Codec (Encoder library)
-ii  libvpx-dev:amd64                   1.3.0-2                                    amd64        VP8 video codec (development files)
-ii  libvpx1:amd64                      1.3.0-2                                    amd64        VP8 video codec (shared library)
-ii  libwayland-client0:amd64           1.4.0-1ubuntu1                             amd64        wayland compositor infrastructure - client library
-ii  libwayland-cursor0:amd64           1.4.0-1ubuntu1                             amd64        wayland compositor infrastructure - cursor library
-ii  libwind0-heimdal:amd64             1.6~git20131207+dfsg-1ubuntu1.2            amd64        Heimdal Kerberos - stringprep implementation
-ii  libwmf-dev                         0.2.8.4-10.3ubuntu1.14.04.1                amd64        Windows metafile conversion development
-ii  libwmf0.2-7:amd64                  0.2.8.4-10.3ubuntu1.14.04.1                amd64        Windows metafile conversion library
-ii  libwrap0:amd64                     7.6.q-25                                   amd64        Wietse Venema's TCP wrappers library
-ii  libx11-6:amd64                     2:1.6.2-1ubuntu2                           amd64        X11 client-side library
-ii  libx11-data                        2:1.6.2-1ubuntu2                           all          X11 client-side library
-ii  libx11-dev:amd64                   2:1.6.2-1ubuntu2                           amd64        X11 client-side library (development headers)
-ii  libx264-142:amd64                  2:0.142.2389+git956c8d8-2                  amd64        x264 video coding library
-ii  libxapian22                        1.2.16-2ubuntu1                            amd64        Search engine library
-ii  libxau-dev:amd64                   1:1.0.8-1                                  amd64        X11 authorisation library (development headers)
-ii  libxau6:amd64                      1:1.0.8-1                                  amd64        X11 authorisation library
-ii  libxcb-render-util0:amd64          0.3.8-1.1ubuntu1                           amd64        utility libraries for X C Binding -- render-util
-ii  libxcb-render0:amd64               1.10-2ubuntu1                              amd64        X C Binding, render extension
-ii  libxcb-render0-dev:amd64           1.10-2ubuntu1                              amd64        X C Binding, render extension, development files
-ii  libxcb-shm0:amd64                  1.10-2ubuntu1                              amd64        X C Binding, shm extension
-ii  libxcb-shm0-dev:amd64              1.10-2ubuntu1                              amd64        X C Binding, shm extension, development files
-ii  libxcb1:amd64                      1.10-2ubuntu1                              amd64        X C Binding
-ii  libxcb1-dev:amd64                  1.10-2ubuntu1                              amd64        X C Binding, development files
-ii  libxcomposite1:amd64               1:0.4.4-1                                  amd64        X11 Composite extension library
-ii  libxcursor1:amd64                  1:1.1.14-1ubuntu0.14.04.1                  amd64        X cursor management library
-ii  libxdamage1:amd64                  1:1.1.4-1ubuntu1                           amd64        X11 damaged region extension library
-ii  libxdmcp-dev:amd64                 1:1.1.1-1                                  amd64        X11 authorisation library (development headers)
-ii  libxdmcp6:amd64                    1:1.1.1-1                                  amd64        X11 Display Manager Control Protocol library
-ii  libxdot4                           2.36.0-0ubuntu3.2                          amd64        rich set of graph drawing tools - xdot library
-ii  libxext-dev:amd64                  2:1.3.2-1ubuntu0.0.14.04.1                 amd64        X11 miscellaneous extensions library (development headers)
-ii  libxext6:amd64                     2:1.3.2-1ubuntu0.0.14.04.1                 amd64        X11 miscellaneous extension library
-ii  libxfixes3:amd64                   1:5.0.1-1ubuntu1.1                         amd64        X11 miscellaneous 'fixes' extension library
-ii  libxft2:amd64                      2.3.1-2                                    amd64        FreeType-based font drawing library for X
-ii  libxi6:amd64                       2:1.7.1.901-1ubuntu1.1                     amd64        X11 Input extension library
-ii  libxinerama1:amd64                 2:1.1.3-1                                  amd64        X11 Xinerama extension library
-ii  libxkbcommon0:amd64                0.4.1-0ubuntu1                             amd64        library interface to the XKB compiler - shared library
-ii  libxml2:amd64                      2.9.1+dfsg1-3ubuntu4.12                    amd64        GNOME XML library
-ii  libxml2-dev:amd64                  2.9.1+dfsg1-3ubuntu4.12                    amd64        Development files for the GNOME XML library
-ii  libxpm-dev:amd64                   1:3.5.10-1ubuntu0.1                        amd64        X11 pixmap library (development headers)
-ii  libxpm4:amd64                      1:3.5.10-1ubuntu0.1                        amd64        X11 pixmap library
-ii  libxrandr2:amd64                   2:1.5.0-1~trusty1                          amd64        X11 RandR extension library
-ii  libxrender-dev:amd64               1:0.9.8-1build0.14.04.1                    amd64        X Rendering Extension client library (development files)
-ii  libxrender1:amd64                  1:0.9.8-1build0.14.04.1                    amd64        X Rendering Extension client library
-ii  libxslt1-dev:amd64                 1.1.28-2ubuntu0.1                          amd64        XSLT 1.0 processing library - development kit
-ii  libxslt1.1:amd64                   1.1.28-2ubuntu0.1                          amd64        XSLT 1.0 processing library - runtime library
-ii  libxt-dev:amd64                    1:1.1.4-1                                  amd64        X11 toolkit intrinsics library (development headers)
-ii  libxt6:amd64                       1:1.1.4-1                                  amd64        X11 toolkit intrinsics library
-ii  libxvidcore4:amd64                 2:1.3.2-9ubuntu1                           amd64        Open source MPEG-4 video codec (library)
-ii  libyaml-0-2:amd64                  0.1.4-3ubuntu3.1                           amd64        Fast YAML 1.1 parser and emitter library
-ii  libyaml-dev:amd64                  0.1.4-3ubuntu3.1                           amd64        Fast YAML 1.1 parser and emitter library (development)
-ii  linux-libc-dev:amd64               3.13.0-137.186                             amd64        Linux Kernel Headers for development
-ii  locales                            2.13+git20120306-12.1                      all          common files for locale support
-ii  lockfile-progs                     0.1.17                                     amd64        Programs for locking and unlocking files and mailboxes
-ii  login                              1:4.1.5.1-1ubuntu9.5                       amd64        system login tools
-ii  logrotate                          3.8.7-1ubuntu1.2                           amd64        Log rotation utility
-ii  lsb-base                           4.1+Debian11ubuntu6.2                      all          Linux Standard Base 4.1 init script functionality
-ii  lsb-release                        4.1+Debian11ubuntu6.2                      all          Linux Standard Base version reporting utility
-ii  lsof                               4.86+dfsg-1ubuntu2                         amd64        Utility to list open files
-ii  lzma                               9.22-2ubuntu2                              amd64        Compression and decompression in the LZMA format - command line utility
-ii  m4                                 1.4.17-2ubuntu1                            amd64        a macro processing language
-ii  make                               3.81-8.2ubuntu3                            amd64        An utility for Directing compilation.
-ii  makedev                            2.3.1-93ubuntu2~ubuntu14.04.1              all          creates device files in /dev
-ii  manpages                           3.54-1ubuntu1                              all          Manual pages about using a GNU/Linux system
-ii  manpages-dev                       3.54-1ubuntu1                              all          Manual pages about using GNU/Linux for development
-ii  mariadb-common                     5.5.57-1ubuntu0.14.04.1                    all          MariaDB common metapackage
-ii  mawk                               1.3.3-17ubuntu2                            amd64        a pattern scanning and text processing language
-ii  mercurial                          2.8.2-1ubuntu1.3                           amd64        easy-to-use, scalable distributed version control system
-ii  mercurial-common                   2.8.2-1ubuntu1.3                           all          easy-to-use, scalable distributed version control system (common files)
-ii  mime-support                       3.54ubuntu1.1                              all          MIME files 'mime.types' & 'mailcap', and support programs
-ii  module-init-tools                  15-0ubuntu6                                all          transitional dummy package (module-init-tools to kmod)
-ii  mount                              2.20.1-5.1ubuntu20.9                       amd64        Tools for mounting and manipulating filesystems
-ii  mountall                           2.53                                       amd64        filesystem mounting tool
-ii  multiarch-support                  2.19-0ubuntu6.13                           amd64        Transitional package to ensure multiarch compatibility
-ii  mysql-common                       5.5.58-0ubuntu0.14.04.1                    all          MySQL database common files, e.g. /etc/mysql/my.cnf
-ii  ncurses-base                       5.9+20140118-1ubuntu1                      all          basic terminal type definitions
-ii  ncurses-bin                        5.9+20140118-1ubuntu1                      amd64        terminal-related programs and man pages
-ii  net-tools                          1.60-25ubuntu2.1                           amd64        The NET-3 networking toolkit
-ii  netbase                            5.2                                        all          Basic TCP/IP networking system
-ii  netcat-openbsd                     1.105-7ubuntu1                             amd64        TCP/IP swiss army knife
-ii  ntpdate                            1:4.2.6.p5+dfsg-3ubuntu2.14.04.12          amd64        client for setting system time from NTP servers
-ii  ocaml-base-nox                     4.01.0-3ubuntu3.1                          amd64        Runtime system for OCaml bytecode executables (no X)
-ii  openssh-client                     1:6.6p1-2ubuntu2.8                         amd64        secure shell (SSH) client, for secure access to remote machines
-ii  openssh-server                     1:6.6p1-2ubuntu2.8                         amd64        secure shell (SSH) server, for secure access from remote machines
-ii  openssh-sftp-server                1:6.6p1-2ubuntu2.8                         amd64        secure shell (SSH) sftp server module, for SFTP access from remote machines
-ii  openssl                            1.0.1f-1ubuntu2.23                         amd64        Secure Sockets Layer toolkit - cryptographic utility
-ii  passwd                             1:4.1.5.1-1ubuntu9.5                       amd64        change and administer password and group data
-ii  patch                              2.7.1-4ubuntu2.3                           amd64        Apply a diff file to an original
-ii  perl                               5.18.2-2ubuntu1.3                          amd64        Larry Wall's Practical Extraction and Report Language
-ii  perl-base                          5.18.2-2ubuntu1.3                          amd64        minimal Perl system
-ii  perl-modules                       5.18.2-2ubuntu1.3                          all          Core Perl modules
-ii  pkg-config                         0.26-1ubuntu4                              amd64        manage compile and link flags for libraries
-ii  plymouth                           0.8.8-0ubuntu17.1                          amd64        graphical boot animation and logger - main package
-ii  procps                             1:3.3.9-1ubuntu2.2                         amd64        /proc file system utilities
-ii  psmisc                             22.20-1ubuntu2                             amd64        utilities that use the proc file system
-ii  python                             2.7.5-5ubuntu3                             amd64        interactive high-level object-oriented language (default version)
-ii  python-bzrlib                      2.6.0+bzr6593-1ubuntu1.6                   amd64        distributed version control system - python library
-ii  python-configobj                   4.7.2+ds-5build1                           all          simple but powerful config file reader and writer for Python
-ii  python-minimal                     2.7.5-5ubuntu3                             amd64        minimal subset of the Python language (default version)
-ii  python2.7                          2.7.6-8ubuntu0.4                           amd64        Interactive high-level object-oriented language (version 2.7)
-ii  python2.7-minimal                  2.7.6-8ubuntu0.4                           amd64        Minimal subset of the Python language (version 2.7)
-ii  python3                            3.4.0-0ubuntu2                             amd64        interactive high-level object-oriented language (default python3 version)
-ii  python3-minimal                    3.4.0-0ubuntu2                             amd64        minimal subset of the Python language (default python3 version)
-ii  python3.4                          3.4.3-1ubuntu1~14.04.6                     amd64        Interactive high-level object-oriented language (version 3.4)
-ii  python3.4-minimal                  3.4.3-1ubuntu1~14.04.6                     amd64        Minimal subset of the Python language (version 3.4)
-ii  quota                              4.01-3                                     amd64        disk quota management tools
-ii  readline-common                    6.3-4ubuntu2                               all          GNU readline and history libraries, common files
-ii  resolvconf                         1.69ubuntu1.3                              all          name server information handler
-ii  rsync                              3.1.0-2ubuntu0.3                           amd64        fast, versatile, remote (and local) file-copying tool
-ii  rsyslog                            7.4.4-1ubuntu2.7                           amd64        reliable system and kernel logging daemon
-ii  sed                                4.2.2-4ubuntu1                             amd64        The GNU sed stream editor
-ii  sensible-utils                     0.0.9                                      all          Utilities for sensible alternative selection
-ii  shared-mime-info                   1.2-0ubuntu3                               amd64        FreeDesktop.org shared MIME database and spec
-ii  sshfs                              2.5-1ubuntu1                               amd64        filesystem client based on SSH File Transfer Protocol
-ii  strace                             4.8-1ubuntu5                               amd64        A system call tracer
-ii  subversion                         1.8.8-1ubuntu3.3                           amd64        Advanced version control system
-ii  sudo                               1.8.9p5-1ubuntu1.4                         amd64        Provide limited super user privileges to specific users
-ii  sysstat                            10.2.0-1                                   amd64        system performance tools for Linux
-ii  sysv-rc                            2.88dsf-41ubuntu6.3                        all          System-V-like runlevel change mechanism
-ii  sysvinit-utils                     2.88dsf-41ubuntu6.3                        amd64        System-V-like utilities
-ii  tar                                1.27.1-1ubuntu0.1                          amd64        GNU version of the tar archiving utility
-ii  tasksel                            2.88ubuntu15                               all          Tool for selecting tasks for installation on Debian systems
-ii  tasksel-data                       2.88ubuntu15                               all          Official tasks used for installation of Debian systems
-ii  tcpdump                            4.9.2-0ubuntu0.14.04.1                     amd64        command-line network traffic analyzer
-ii  traceroute                         1:2.0.20-0ubuntu0.1                        amd64        Traces the route taken by packets over an IPv4/IPv6 network
-ii  tsconf                             1.0-12                                     all          touch screen library common files
-ii  ttf-dejavu-core                    2.34-1ubuntu1                              all          transitional dummy package
-ii  tzdata                             2017c-0ubuntu0.14.04                       all          time zone and daylight-saving time data
-ii  ubuntu-keyring                     2012.05.19                                 all          GnuPG keys of the Ubuntu archive
-ii  ubuntu-minimal                     1.325                                      amd64        Minimal core of Ubuntu
-ii  ucf                                3.0027+nmu1                                all          Update Configuration File(s): preserve user changes to config files
-ii  udev                               204-5ubuntu20.25                           amd64        /dev/ and hotplug management daemon
-ii  unzip                              6.0-9ubuntu1.5                             amd64        De-archiver for .zip files
-ii  upstart                            1.12.1-0ubuntu4.2                          amd64        event-based init daemon
-ii  ureadahead                         0.100.0-16                                 amd64        Read required files in advance
-ii  util-linux                         2.20.1-5.1ubuntu20.9                       amd64        Miscellaneous system utilities
-ii  uuid-dev                           2.20.1-5.1ubuntu20.9                       amd64        universally unique id library - headers and static libraries
-ii  vim-common                         2:7.4.052-1ubuntu3.1                       amd64        Vi IMproved - Common files
-ii  vim-tiny                           2:7.4.052-1ubuntu3.1                       amd64        Vi IMproved - enhanced vi editor - compact version
-ii  wget                               1.15-1ubuntu1.14.04.3                      amd64        retrieves files from the web
-ii  whiptail                           0.52.15-2ubuntu5                           amd64        Displays user-friendly dialog boxes from shell scripts
-ii  x11-common                         1:7.7+1ubuntu8.1                           all          X Window System (X.Org) infrastructure
-ii  x11proto-core-dev                  7.0.26-1~ubuntu2                           all          X11 core wire protocol and auxiliary headers
-ii  x11proto-input-dev                 2.3-1                                      all          X11 Input extension wire protocol
-ii  x11proto-kb-dev                    1.0.6-2                                    all          X11 XKB extension wire protocol
-ii  x11proto-render-dev                2:0.11.1-2                                 all          X11 Render extension wire protocol
-ii  x11proto-xext-dev                  7.3.0-1                                    all          X11 various extension wire protocol
-ii  xkb-data                           2.10.1-1ubuntu1                            all          X Keyboard Extension (XKB) configuration data
-ii  xorg-sgml-doctools                 1:1.11-1                                   all          Common tools for building X.Org SGML documentation
-ii  xtrans-dev                         1.3.5-1~ubuntu14.04.2                      all          X transport library (development files)
-ii  xz-utils                           5.1.1alpha+20120614-2ubuntu2               amd64        XZ-format compression utilities
-ii  zip                                3.0-8                                      amd64        Archiver for .zip files
-ii  zlib1g:amd64                       1:1.2.8.dfsg-1ubuntu1                      amd64        compression library - runtime
-ii  zlib1g-dev:amd64                   1:1.2.8.dfsg-1ubuntu1                      amd64        compression library - development
+||/ Name                               Version                           Architecture Description
++++-==================================-=================================-============-===============================================================================
+ii  adduser                            3.116ubuntu1                      all          add and remove users and groups
+ii  adwaita-icon-theme                 3.27.90-1ubuntu1                  all          default icon theme of GNOME (small subset)
+ii  apt                                1.6~beta1                         amd64        commandline package manager
+ii  apt-utils                          1.6~beta1                         amd64        package management related utility programs
+ii  aptitude                           0.8.10-6ubuntu1                   amd64        terminal-based package manager
+ii  aptitude-common                    0.8.10-6ubuntu1                   all          architecture independent files for the aptitude package manager
+ii  autoconf                           2.69-11                           all          automatic configure script builder
+ii  base-files                         10ubuntu1                         amd64        Debian base system miscellaneous files
+ii  base-passwd                        3.5.44                            amd64        Debian base system master password and group files
+ii  bash                               4.4.18-1ubuntu1                   amd64        GNU Bourne Again SHell
+ii  bind9-host                         1:9.11.2.P1-1ubuntu5              amd64        Version of 'host' bundled with BIND 9.X
+ii  binutils                           2.30-11ubuntu1                    amd64        GNU assembler, linker and binary utilities
+ii  binutils-common:amd64              2.30-11ubuntu1                    amd64        Common files for the GNU assembler, linker and binary utilities
+ii  binutils-x86-64-linux-gnu          2.30-11ubuntu1                    amd64        GNU binary utilities, for x86-64-linux-gnu target
+ii  bison                              2:3.0.4.dfsg-1build1              amd64        YACC-compatible parser generator
+ii  bsdutils                           1:2.31.1-0.4ubuntu3               amd64        basic utilities from 4.4BSD-Lite
+ii  build-essential                    12.4ubuntu1                       amd64        Informational list of build-essential packages
+ii  busybox-initramfs                  1:1.27.2-2ubuntu3                 amd64        Standalone shell setup for initramfs
+ii  bzip2                              1.0.6-8.1                         amd64        high-quality block-sorting file compressor - utilities
+ii  bzr                                2.7.0+bzr6622-10                  all          easy to use distributed version control system
+ii  ca-certificates                    20170717                          all          Common CA certificates
+ii  cmake                              3.10.2-1build1                    amd64        cross-platform, open-source make system
+ii  cmake-data                         3.10.2-1build1                    all          CMake data files (modules, templates and documentation)
+ii  console-setup                      1.178ubuntu1                      all          console font and keymap setup program
+ii  console-setup-linux                1.178ubuntu1                      all          Linux specific part of console-setup
+ii  coreutils                          8.28-1ubuntu1                     amd64        GNU core utilities
+ii  cpio                               2.12+dfsg-6                       amd64        GNU cpio -- a program to manage archives of files
+ii  cpp                                4:7.3.0-2ubuntu1                  amd64        GNU C preprocessor (cpp)
+ii  cpp-7                              7.3.0-14ubuntu1                   amd64        GNU C preprocessor
+ii  curl                               7.58.0-2ubuntu3                   amd64        command line tool for transferring data with URL syntax
+ii  dash                               0.5.8-2.10                        amd64        POSIX-compliant shell
+ii  dconf-gsettings-backend:amd64      0.26.0-2ubuntu3                   amd64        simple configuration storage system - GSettings back-end
+ii  dconf-service                      0.26.0-2ubuntu3                   amd64        simple configuration storage system - D-Bus service
+ii  debconf                            1.5.66                            all          Debian configuration management system
+ii  debconf-i18n                       1.5.66                            all          full internationalization support for debconf
+ii  debianutils                        4.8.4                             amd64        Miscellaneous utilities specific to Debian
+ii  dh-python                          3.20180325ubuntu2                 all          Debian helper tools for packaging Python libraries and applications
+ii  diffutils                          1:3.6-1                           amd64        File comparison utilities
+ii  dirmngr                            2.2.4-1ubuntu1                    amd64        GNU privacy guard - network certificate management service
+ii  distro-info-data                   0.37                              all          information about the distributions' releases (data files)
+ii  dnsutils                           1:9.11.2.P1-1ubuntu5              amd64        Clients provided with BIND
+ii  dpkg                               1.19.0.5ubuntu1                   amd64        Debian package management system
+ii  dpkg-dev                           1.19.0.5ubuntu1                   all          Debian package development tools
+ii  e2fslibs:amd64                     1.44.1-1                          amd64        transitional package
+ii  e2fsprogs                          1.44.1-1                          amd64        ext2/ext3/ext4 file system utilities
+ii  eject                              2.1.5+deb1+cvs20081104-13.2       amd64        ejects CDs and operates CD-Changers under Linux
+ii  fakeroot                           1.22-2ubuntu1                     amd64        tool for simulating superuser privileges
+ii  fdisk                              2.31.1-0.4ubuntu3                 amd64        collection of partitioning utilities
+ii  findutils                          4.6.0+git+20170828-2              amd64        utilities for finding files--find, xargs
+ii  flex                               2.6.4-6                           amd64        fast lexical analyzer generator
+ii  fontconfig                         2.12.6-0ubuntu1                   amd64        generic font configuration library - support binaries
+ii  fontconfig-config                  2.12.6-0ubuntu1                   all          generic font configuration library - configuration
+ii  fonts-dejavu-core                  2.37-1                            all          Vera font family derivate with additional characters
+ii  fuse                               2.9.7-1ubuntu1                    amd64        Filesystem in Userspace
+ii  fuse-emulator-utils                1.4.0-1                           amd64        The Free Unix Spectrum Emulator - Utilities
+ii  g++                                4:7.3.0-2ubuntu1                  amd64        GNU C++ compiler
+ii  g++-7                              7.3.0-14ubuntu1                   amd64        GNU C++ compiler
+ii  gcc                                4:7.3.0-2ubuntu1                  amd64        GNU C compiler
+ii  gcc-7                              7.3.0-14ubuntu1                   amd64        GNU C compiler
+ii  gcc-7-base:amd64                   7.3.0-14ubuntu1                   amd64        GCC, the GNU Compiler Collection (base package)
+ii  gcc-8-base:amd64                   8-20180402-1ubuntu1               amd64        GCC, the GNU Compiler Collection (base package)
+ii  gdb                                8.1-0ubuntu2                      amd64        GNU Debugger
+ii  gir1.2-freedesktop:amd64           1.56.0-2                          amd64        Introspection data for some FreeDesktop components
+ii  gir1.2-gdkpixbuf-2.0:amd64         2.36.11-2                         amd64        GDK Pixbuf library - GObject-Introspection
+ii  gir1.2-glib-2.0:amd64              1.56.0-2                          amd64        Introspection data for GLib, GObject, Gio and GModule
+ii  gir1.2-harfbuzz-0.0:amd64          1.7.2-1                           amd64        OpenType text shaping engine (GObject introspection data)
+ii  gir1.2-rsvg-2.0:amd64              2.40.20-2                         amd64        gir files for renderer library for SVG files
+ii  git                                1:2.15.1-1ubuntu2                 amd64        fast, scalable, distributed revision control system
+ii  git-man                            1:2.15.1-1ubuntu2                 all          fast, scalable, distributed revision control system (manual pages)
+ii  glib-networking:amd64              2.56.0-1                          amd64        network-related giomodules for GLib
+ii  glib-networking-common             2.56.0-1                          all          network-related giomodules for GLib - data files
+ii  glib-networking-services           2.56.0-1                          amd64        network-related giomodules for GLib - D-Bus services
+ii  gnupg                              2.2.4-1ubuntu1                    amd64        GNU privacy guard - a free PGP replacement
+ii  gnupg-l10n                         2.2.4-1ubuntu1                    all          GNU privacy guard - localization files
+ii  gnupg-utils                        2.2.4-1ubuntu1                    amd64        GNU privacy guard - utility programs
+ii  gnupg1                             1.4.22-3ubuntu2                   amd64        GNU privacy guard - a PGP implementation (deprecated "classic" version)
+ii  gpg                                2.2.4-1ubuntu1                    amd64        GNU Privacy Guard -- minimalist public key operations
+ii  gpg-agent                          2.2.4-1ubuntu1                    amd64        GNU privacy guard - cryptographic agent
+ii  gpg-wks-client                     2.2.4-1ubuntu1                    amd64        GNU privacy guard - Web Key Service client
+ii  gpg-wks-server                     2.2.4-1ubuntu1                    amd64        GNU privacy guard - Web Key Service server
+ii  gpgconf                            2.2.4-1ubuntu1                    amd64        GNU privacy guard - core configuration utilities
+ii  gpgsm                              2.2.4-1ubuntu1                    amd64        GNU privacy guard - S/MIME version
+ii  gpgv                               2.2.4-1ubuntu1                    amd64        GNU privacy guard - signature verification tool
+ii  grep                               3.1-2                             amd64        GNU grep, egrep and fgrep
+ii  gsettings-desktop-schemas          3.27.90-1ubuntu1                  all          GSettings desktop-wide schemas
+ii  gsfonts                            1:8.11+urwcyr1.0.7~pre44-4.4      all          Fonts for the Ghostscript interpreter(s)
+ii  gtk-update-icon-cache              3.22.29-2ubuntu1                  amd64        icon theme caching utility
+ii  gzip                               1.6-5ubuntu1                      amd64        GNU compression utilities
+ii  hicolor-icon-theme                 0.17-2                            all          default fallback theme for FreeDesktop.org icon themes
+ii  hostname                           3.20                              amd64        utility to set/show the host name or domain name
+ii  humanity-icon-theme                0.6.15                            all          Humanity Icon theme
+ii  icu-devtools                       60.2-3ubuntu3                     amd64        Development utilities for International Components for Unicode
+ii  imagemagick                        8:6.9.7.4+dfsg-16ubuntu5          amd64        image manipulation programs -- binaries
+ii  imagemagick-6-common               8:6.9.7.4+dfsg-16ubuntu5          all          image manipulation programs -- infrastructure
+ii  imagemagick-6.q16                  8:6.9.7.4+dfsg-16ubuntu5          amd64        image manipulation programs -- quantum depth Q16
+ii  init                               1.51                              amd64        metapackage ensuring an init system is installed
+ii  init-system-helpers                1.51                              all          helper tools for all init systems
+ii  initramfs-tools                    0.130ubuntu3                      all          generic modular initramfs generator (automation)
+ii  initramfs-tools-bin                0.130ubuntu3                      amd64        binaries used by initramfs-tools
+ii  initramfs-tools-core               0.130ubuntu3                      all          generic modular initramfs generator (core tools)
+ii  iproute2                           4.15.0-2ubuntu1                   amd64        networking and traffic control tools
+ii  iputils-arping                     3:20161105-1ubuntu2               amd64        Tool to send ICMP echo requests to an ARP address
+ii  iputils-ping                       3:20161105-1ubuntu2               amd64        Tools to test the reachability of network hosts
+ii  isc-dhcp-client                    4.3.5-3ubuntu6                    amd64        DHCP client for automatically obtaining an IP address
+ii  jq                                 1.5+dfsg-2                        amd64        lightweight and flexible command-line JSON processor
+ii  kbd                                2.0.4-2ubuntu1                    amd64        Linux console font and keytable utilities
+ii  keyboard-configuration             1.178ubuntu1                      all          system-wide keyboard preferences
+ii  klibc-utils                        2.0.4-9ubuntu2                    amd64        small utilities built with klibc for early boot
+ii  kmod                               24-1ubuntu3                       amd64        tools for managing Linux kernel modules
+ii  krb5-config                        2.6                               all          Configuration files for Kerberos Version 5
+ii  krb5-user                          1.16-2build1                      amd64        basic programs to authenticate using MIT Kerberos
+ii  laptop-detect                      0.16                              all          system chassis type checker
+ii  less                               487-0.1                           amd64        pager program similar to more
+ii  libacl1:amd64                      2.2.52-3build1                    amd64        Access control list shared library
+ii  libaio1:amd64                      0.3.110-5                         amd64        Linux kernel AIO access library - shared library
+ii  libapparmor1:amd64                 2.12-4ubuntu3                     amd64        changehat AppArmor library
+ii  libapr1:amd64                      1.6.3-2                           amd64        Apache Portable Runtime Library
+ii  libaprutil1:amd64                  1.6.1-2                           amd64        Apache Portable Runtime Utility Library
+ii  libapt-inst2.0:amd64               1.6~beta1                         amd64        deb package format runtime library
+ii  libapt-pkg5.0:amd64                1.6~beta1                         amd64        package management runtime library
+ii  libarchive13:amd64                 3.2.2-3.1                         amd64        Multi-format archive and compression library (shared library)
+ii  libargon2-0:amd64                  0~20161029-1.1                    amd64        memory-hard hashing function - runtime library
+ii  libargon2-0-dev:amd64              0~20161029-1.1                    amd64        memory-hard hashing function - development files
+ii  libasan4:amd64                     7.3.0-14ubuntu1                   amd64        AddressSanitizer -- a fast memory error detector
+ii  libasn1-8-heimdal:amd64            7.5.0+dfsg-1                      amd64        Heimdal Kerberos - ASN.1 library
+ii  libassuan0:amd64                   2.5.1-2                           amd64        IPC library for the GnuPG components
+ii  libatk-bridge2.0-0:amd64           2.26.2-1                          amd64        AT-SPI 2 toolkit bridge - shared library
+ii  libatk1.0-0:amd64                  2.28.1-1                          amd64        ATK accessibility toolkit
+ii  libatk1.0-data                     2.28.1-1                          all          Common files for the ATK accessibility toolkit
+ii  libatm1:amd64                      1:2.5.1-2build1                   amd64        shared library for ATM (Asynchronous Transfer Mode)
+ii  libatomic1:amd64                   8-20180402-1ubuntu1               amd64        support library providing __atomic built-in functions
+ii  libatspi2.0-0:amd64                2.28.0-1                          amd64        Assistive Technology Service Provider Interface - shared library
+ii  libattr1:amd64                     1:2.4.47-2build1                  amd64        Extended attribute shared library
+ii  libaudiofile1:amd64                0.3.6-4                           amd64        Open-source version of SGI's audiofile library
+ii  libaudit-common                    1:2.8.2-1ubuntu1                  all          Dynamic library for security auditing - common files
+ii  libaudit1:amd64                    1:2.8.2-1ubuntu1                  amd64        Dynamic library for security auditing
+ii  libavahi-client3:amd64             0.7-3.1ubuntu1                    amd64        Avahi client library
+ii  libavahi-common-data:amd64         0.7-3.1ubuntu1                    amd64        Avahi common data files
+ii  libavahi-common3:amd64             0.7-3.1ubuntu1                    amd64        Avahi common library
+ii  libavcodec57:amd64                 7:3.4.2-1build1                   amd64        FFmpeg library with de/encoders for audio/video codecs - runtime files
+ii  libavutil55:amd64                  7:3.4.2-1build1                   amd64        FFmpeg library with functions for simplifying programming - runtime files
+ii  libbabeltrace1:amd64               1.5.5-1                           amd64        Babeltrace conversion libraries
+ii  libbind9-160:amd64                 1:9.11.2.P1-1ubuntu5              amd64        BIND9 Shared Library used by BIND
+ii  libbinutils:amd64                  2.30-11ubuntu1                    amd64        GNU binary utilities (private shared library)
+ii  libbison-dev:amd64                 2:3.0.4.dfsg-1build1              amd64        YACC-compatible parser generator - development library
+ii  libblkid1:amd64                    2.31.1-0.4ubuntu3                 amd64        block device ID library
+ii  libboost-filesystem1.65.1:amd64    1.65.1+dfsg-0ubuntu5              amd64        filesystem operations (portable paths, iteration over directories, etc) in C++
+ii  libboost-iostreams1.62.0:amd64     1.62.0+dfsg-5                     amd64        Boost.Iostreams Library
+ii  libboost-iostreams1.65.1:amd64     1.65.1+dfsg-0ubuntu5              amd64        Boost.Iostreams Library
+ii  libboost-system1.65.1:amd64        1.65.1+dfsg-0ubuntu5              amd64        Operating system (e.g. diagnostics support) library
+ii  libbsd0:amd64                      0.8.7-1                           amd64        utility functions from BSD systems - shared library
+ii  libbz2-1.0:amd64                   1.0.6-8.1                         amd64        high-quality block-sorting file compressor library - runtime
+ii  libbz2-dev:amd64                   1.0.6-8.1                         amd64        high-quality block-sorting file compressor library - development
+ii  libc-bin                           2.27-0ubuntu2                     amd64        GNU C Library: Binaries
+ii  libc-dev-bin                       2.27-0ubuntu2                     amd64        GNU C Library: Development binaries
+ii  libc6:amd64                        2.27-0ubuntu2                     amd64        GNU C Library: Shared libraries
+ii  libc6-dev:amd64                    2.27-0ubuntu2                     amd64        GNU C Library: Development Libraries and Header Files
+ii  libcairo-gobject2:amd64            1.15.10-2                         amd64        Cairo 2D vector graphics library (GObject library)
+ii  libcairo-script-interpreter2:amd64 1.15.10-2                         amd64        Cairo 2D vector graphics library (script interpreter)
+ii  libcairo2:amd64                    1.15.10-2                         amd64        Cairo 2D vector graphics library
+ii  libcairo2-dev:amd64                1.15.10-2                         amd64        Development files for the Cairo 2D graphics library
+ii  libcap-ng0:amd64                   0.7.7-3.1                         amd64        An alternate POSIX capabilities library
+ii  libcap2:amd64                      1:2.25-1.2                        amd64        POSIX 1003.1e capabilities (library)
+ii  libcc1-0:amd64                     8-20180402-1ubuntu1               amd64        GCC cc1 plugin for GDB
+ii  libcgi-pm-perl                     4.38-1                            all          module for Common Gateway Interface applications
+ii  libcilkrts5:amd64                  7.3.0-14ubuntu1                   amd64        Intel Cilk Plus language extensions (runtime)
+ii  libclass-accessor-perl             0.51-1                            all          Perl module that automatically generates accessors
+ii  libcolord2:amd64                   1.3.3-2build1                     amd64        system service to manage device colour profiles -- runtime
+ii  libcom-err2:amd64                  1.44.1-1                          amd64        common error description library
+ii  libcomerr2:amd64                   1.44.1-1                          amd64        transitional package
+ii  libcroco3:amd64                    0.6.12-2                          amd64        Cascading Style Sheet (CSS) parsing and manipulation toolkit
+ii  libcryptsetup12:amd64              2:2.0.1-0ubuntu2                  amd64        disk encryption support - shared library
+ii  libcrystalhd3:amd64                1:0.0~git20110715.fdd2f19-12      amd64        Crystal HD Video Decoder (shared library)
+ii  libcups2:amd64                     2.2.7-1ubuntu1                    amd64        Common UNIX Printing System(tm) - Core library
+ii  libcurl3-gnutls:amd64              7.58.0-2ubuntu3                   amd64        easy-to-use client-side URL transfer library (GnuTLS flavour)
+ii  libcurl4:amd64                     7.58.0-2ubuntu3                   amd64        easy-to-use client-side URL transfer library (OpenSSL flavour)
+ii  libcurl4-openssl-dev:amd64         7.58.0-2ubuntu3                   amd64        development files and documentation for libcurl (OpenSSL flavour)
+ii  libcwidget3v5:amd64                0.5.17-7                          amd64        high-level terminal interface library for C++ (runtime files)
+ii  libdatrie1:amd64                   0.2.10-7                          amd64        Double-array trie library
+ii  libdb5.3:amd64                     5.3.28-13.1                       amd64        Berkeley v5.3 Database Libraries [runtime]
+ii  libdbus-1-3:amd64                  1.12.2-1ubuntu1                   amd64        simple interprocess messaging system (library)
+ii  libdconf1:amd64                    0.26.0-2ubuntu3                   amd64        simple configuration storage system - runtime library
+ii  libdebconfclient0:amd64            0.213ubuntu1                      amd64        Debian Configuration Management System (C-implementation library)
+ii  libdevmapper1.02.1:amd64           2:1.02.145-4.1ubuntu2             amd64        Linux Kernel Device Mapper userspace library
+ii  libdirectfb-1.7-7:amd64            1.7.7-8                           amd64        direct frame buffer graphics (shared libraries)
+ii  libdjvulibre-dev:amd64             3.5.27.1-8                        amd64        Development files for the DjVu image format
+ii  libdjvulibre-text                  3.5.27.1-8                        all          Linguistic support files for libdjvulibre
+ii  libdjvulibre21:amd64               3.5.27.1-8                        amd64        Runtime support for the DjVu image format
+ii  libdns-export169                   1:9.11.2.P1-1ubuntu5              amd64        Exported DNS Shared Library
+ii  libdns169:amd64                    1:9.11.2.P1-1ubuntu5              amd64        DNS Shared Library used by BIND
+ii  libdpkg-perl                       1.19.0.5ubuntu1                   all          Dpkg perl modules
+ii  libdrm-amdgpu1:amd64               2.4.91-2                          amd64        Userspace interface to amdgpu-specific kernel DRM services -- runtime
+ii  libdrm-common                      2.4.91-2                          all          Userspace interface to kernel DRM services -- common files
+ii  libdrm-intel1:amd64                2.4.91-2                          amd64        Userspace interface to intel-specific kernel DRM services -- runtime
+ii  libdrm-nouveau2:amd64              2.4.91-2                          amd64        Userspace interface to nouveau-specific kernel DRM services -- runtime
+ii  libdrm-radeon1:amd64               2.4.91-2                          amd64        Userspace interface to radeon-specific kernel DRM services -- runtime
+ii  libdrm2:amd64                      2.4.91-2                          amd64        Userspace interface to kernel DRM services -- runtime
+ii  libdw1:amd64                       0.170-0.3                         amd64        library that provides access to the DWARF debug information
+ii  libedit2:amd64                     3.1-20170329-1                    amd64        BSD editline and history libraries
+ii  libegl-mesa0:amd64                 18.0.0~rc5-1ubuntu1               amd64        free implementation of the EGL API -- Mesa vendor library
+ii  libegl1:amd64                      1.0.0-2ubuntu2                    amd64        Vendor neutral GL dispatch library -- EGL support
+ii  libelf1:amd64                      0.170-0.3                         amd64        library to read and write ELF files
+ii  libepoxy0:amd64                    1.4.3-1                           amd64        OpenGL function pointer management library
+ii  libept1.5.0:amd64                  1.1+nmu3build1                    amd64        High-level library for managing Debian package information
+ii  liberror-perl                      0.17025-1                         all          Perl module for error/exception handling in an OO-ish way
+ii  libexif-dev:amd64                  0.6.21-4                          amd64        library to parse EXIF files (development files)
+ii  libexif12:amd64                    0.6.21-4                          amd64        library to parse EXIF files
+ii  libexpat1:amd64                    2.2.5-3                           amd64        XML parsing C library - runtime library
+ii  libexpat1-dev:amd64                2.2.5-3                           amd64        XML parsing C library - development kit
+ii  libext2fs2:amd64                   1.44.1-1                          amd64        ext2/ext3/ext4 file system libraries
+ii  libfakeroot:amd64                  1.22-2ubuntu1                     amd64        tool for simulating superuser privileges - shared libraries
+ii  libfdisk1:amd64                    2.31.1-0.4ubuntu3                 amd64        fdisk partitioning library
+ii  libffi6:amd64                      3.2.1-8                           amd64        Foreign Function Interface library runtime
+ii  libfftw3-double3:amd64             3.3.7-1                           amd64        Library for computing Fast Fourier Transforms - Double precision
+ii  libflac8:amd64                     1.3.2-1                           amd64        Free Lossless Audio Codec - runtime C library
+ii  libfontconfig1:amd64               2.12.6-0ubuntu1                   amd64        generic font configuration library - runtime
+ii  libfontconfig1-dev:amd64           2.12.6-0ubuntu1                   amd64        generic font configuration library - development
+ii  libfreetype6:amd64                 2.8.1-2ubuntu1                    amd64        FreeType 2 font engine, shared library files
+ii  libfreetype6-dev:amd64             2.8.1-2ubuntu1                    amd64        FreeType 2 font engine, development files
+ii  libfuse-dev                        2.9.7-1ubuntu1                    amd64        Filesystem in Userspace (development)
+ii  libfuse2:amd64                     2.9.7-1ubuntu1                    amd64        Filesystem in Userspace (library)
+ii  libgbm1:amd64                      18.0.0~rc5-1ubuntu1               amd64        generic buffer management API -- runtime
+ii  libgcc-7-dev:amd64                 7.3.0-14ubuntu1                   amd64        GCC support library (development files)
+ii  libgcc1:amd64                      1:8-20180402-1ubuntu1             amd64        GCC support library
+ii  libgcrypt20:amd64                  1.8.1-4ubuntu1                    amd64        LGPL Crypto library - runtime library
+ii  libgd-dev:amd64                    2.2.5-4                           amd64        GD Graphics Library (development version)
+ii  libgd3:amd64                       2.2.5-4                           amd64        GD Graphics Library
+ii  libgdbm-compat4:amd64              1.14.1-6                          amd64        GNU dbm database routines (legacy support runtime version) 
+ii  libgdbm5:amd64                     1.14.1-6                          amd64        GNU dbm database routines (runtime version) 
+ii  libgdk-pixbuf2.0-0:amd64           2.36.11-2                         amd64        GDK Pixbuf library
+ii  libgdk-pixbuf2.0-common            2.36.11-2                         all          GDK Pixbuf library - data files
+ii  libgdk-pixbuf2.0-dev               2.36.11-2                         amd64        GDK Pixbuf library (development files)
+ii  libgeoip1:amd64                    1.6.12-1                          amd64        non-DNS IP-to-country resolver library
+ii  libgfortran4:amd64                 7.3.0-14ubuntu1                   amd64        Runtime library for GNU Fortran applications
+ii  libgirepository-1.0-1:amd64        1.56.0-2                          amd64        Library for handling GObject introspection data (runtime library)
+ii  libgl1:amd64                       1.0.0-2ubuntu2                    amd64        Vendor neutral GL dispatch library -- legacy GL support
+ii  libgl1-mesa-dri:amd64              18.0.0~rc5-1ubuntu1               amd64        free implementation of the OpenGL API -- DRI modules
+ii  libglapi-mesa:amd64                18.0.0~rc5-1ubuntu1               amd64        free implementation of the GL API -- shared library
+ii  libgles2:amd64                     1.0.0-2ubuntu2                    amd64        Vendor neutral GL dispatch library -- GLES support
+ii  libglib2.0-0:amd64                 2.56.0-4ubuntu1                   amd64        GLib library of C routines
+ii  libglib2.0-bin                     2.56.0-4ubuntu1                   amd64        Programs for the GLib library
+ii  libglib2.0-data                    2.56.0-4ubuntu1                   all          Common files for GLib library
+ii  libglib2.0-dev:amd64               2.56.0-4ubuntu1                   amd64        Development files for the GLib library
+ii  libglib2.0-dev-bin                 2.56.0-4ubuntu1                   amd64        Development utilities for the GLib library
+ii  libglvnd0:amd64                    1.0.0-2ubuntu2                    amd64        Vendor neutral GL dispatch library
+ii  libglx-mesa0:amd64                 18.0.0~rc5-1ubuntu1               amd64        free implementation of the OpenGL API -- GLX vendor library
+ii  libglx0:amd64                      1.0.0-2ubuntu2                    amd64        Vendor neutral GL dispatch library -- GLX support
+ii  libgmp-dev:amd64                   2:6.1.2+dfsg-2                    amd64        Multiprecision arithmetic library developers tools
+ii  libgmp10:amd64                     2:6.1.2+dfsg-2                    amd64        Multiprecision arithmetic library
+ii  libgmpxx4ldbl:amd64                2:6.1.2+dfsg-2                    amd64        Multiprecision arithmetic library (C++ bindings)
+ii  libgnutls30:amd64                  3.5.18-1ubuntu1                   amd64        GNU TLS library - main runtime library
+ii  libgomp1:amd64                     8-20180402-1ubuntu1               amd64        GCC OpenMP (GOMP) support library
+ii  libgpg-error0:amd64                1.27-6                            amd64        library for common error values and messages in GnuPG components
+ii  libgpm2:amd64                      1.20.7-5                          amd64        General Purpose Mouse - shared library
+ii  libgraphite2-3:amd64               1.3.11-2                          amd64        Font rendering engine for Complex Scripts -- library
+ii  libgraphite2-dev:amd64             1.3.11-2                          amd64        Development files for libgraphite2
+ii  libgsm1:amd64                      1.0.13-4                          amd64        Shared libraries for GSM speech compressor
+ii  libgssapi-krb5-2:amd64             1.16-2build1                      amd64        MIT Kerberos runtime libraries - krb5 GSS-API Mechanism
+ii  libgssapi3-heimdal:amd64           7.5.0+dfsg-1                      amd64        Heimdal Kerberos - GSSAPI support library
+ii  libgssrpc4:amd64                   1.16-2build1                      amd64        MIT Kerberos runtime libraries - GSS enabled ONCRPC
+ii  libgtk-3-0:amd64                   3.22.29-2ubuntu1                  amd64        GTK+ graphical user interface library
+ii  libgtk-3-common                    3.22.29-2ubuntu1                  all          common files for the GTK+ graphical user interface library
+ii  libharfbuzz-dev:amd64              1.7.2-1                           amd64        Development files for OpenType text shaping engine
+ii  libharfbuzz-gobject0:amd64         1.7.2-1                           amd64        OpenType text shaping engine ICU backend (GObject library)
+ii  libharfbuzz-icu0:amd64             1.7.2-1                           amd64        OpenType text shaping engine ICU backend
+ii  libharfbuzz0b:amd64                1.7.2-1                           amd64        OpenType text shaping engine (shared library)
+ii  libhcrypto4-heimdal:amd64          7.5.0+dfsg-1                      amd64        Heimdal Kerberos - crypto library
+ii  libheimbase1-heimdal:amd64         7.5.0+dfsg-1                      amd64        Heimdal Kerberos - Base library
+ii  libheimntlm0-heimdal:amd64         7.5.0+dfsg-1                      amd64        Heimdal Kerberos - NTLM support library
+ii  libhogweed4:amd64                  3.4-1                             amd64        low level cryptographic library (public-key cryptos)
+ii  libhtml-parser-perl                3.72-3build1                      amd64        collection of modules that parse HTML text documents
+ii  libhtml-tagset-perl                3.20-3                            all          Data tables pertaining to HTML
+ii  libhx509-5-heimdal:amd64           7.5.0+dfsg-1                      amd64        Heimdal Kerberos - X509 support library
+ii  libice-dev:amd64                   2:1.0.9-2                         amd64        X11 Inter-Client Exchange library (development headers)
+ii  libice6:amd64                      2:1.0.9-2                         amd64        X11 Inter-Client Exchange library
+ii  libicu-dev                         60.2-3ubuntu3                     amd64        Development files for International Components for Unicode
+ii  libicu-le-hb-dev:amd64             1.0.3+git161113-4                 amd64        ICU Layout Engine API on top of HarfBuzz shaping library (development)
+ii  libicu-le-hb0:amd64                1.0.3+git161113-4                 amd64        ICU Layout Engine API on top of HarfBuzz shaping library
+ii  libicu60:amd64                     60.2-3ubuntu3                     amd64        International Components for Unicode
+ii  libiculx60:amd64                   60.2-3ubuntu3                     amd64        International Components for Unicode
+ii  libidn11:amd64                     1.33-2.1ubuntu1                   amd64        GNU Libidn library, implementation of IETF IDN specifications
+ii  libidn2-0:amd64                    2.0.4-1.1build2                   amd64        Internationalized domain names (IDNA2008/TR46) library
+ii  libilmbase-dev                     2.2.0-11ubuntu2                   amd64        development files for IlmBase
+ii  libilmbase12:amd64                 2.2.0-11ubuntu2                   amd64        several utility libraries from ILM used by OpenEXR
+ii  libio-string-perl                  1.08-3                            all          Emulate IO::File interface for in-core strings
+ii  libip4tc0:amd64                    1.6.1-2ubuntu2                    amd64        netfilter libip4tc library
+ii  libirs160:amd64                    1:9.11.2.P1-1ubuntu5              amd64        DNS Shared Library used by BIND
+ii  libisc-export166:amd64             1:9.11.2.P1-1ubuntu5              amd64        Exported ISC Shared Library
+ii  libisc166:amd64                    1:9.11.2.P1-1ubuntu5              amd64        ISC Shared Library used by BIND
+ii  libisccc160:amd64                  1:9.11.2.P1-1ubuntu5              amd64        Command Channel Library used by BIND
+ii  libisccfg160:amd64                 1:9.11.2.P1-1ubuntu5              amd64        Config File Handling Library used by BIND
+ii  libisl19:amd64                     0.19-1                            amd64        manipulating sets and relations of integer points bounded by linear constraints
+ii  libitm1:amd64                      8-20180402-1ubuntu1               amd64        GNU Transactional Memory Library
+ii  libjbig-dev:amd64                  2.1-3.1                           amd64        JBIGkit development files
+ii  libjbig0:amd64                     2.1-3.1                           amd64        JBIGkit libraries
+ii  libjpeg-dev:amd64                  8c-2ubuntu8                       amd64        Independent JPEG Group's JPEG runtime library (dependency package)
+ii  libjpeg-turbo8:amd64               1.5.2-0ubuntu5                    amd64        IJG JPEG compliant runtime library.
+ii  libjpeg-turbo8-dev:amd64           1.5.2-0ubuntu5                    amd64        Development files for the IJG JPEG library
+ii  libjpeg8:amd64                     8c-2ubuntu8                       amd64        Independent JPEG Group's JPEG runtime library (dependency package)
+ii  libjpeg8-dev:amd64                 8c-2ubuntu8                       amd64        Independent JPEG Group's JPEG runtime library (dependency package)
+ii  libjq1:amd64                       1.5+dfsg-2                        amd64        lightweight and flexible command-line JSON processor - shared library
+ii  libjson-c3:amd64                   0.12.1-1.3                        amd64        JSON manipulation library - shared library
+ii  libjson-glib-1.0-0:amd64           1.4.2-3                           amd64        GLib JSON manipulation library
+ii  libjson-glib-1.0-common            1.4.2-3                           all          GLib JSON manipulation library (common files)
+ii  libjsoncpp1:amd64                  1.7.4-3                           amd64        library for reading and writing JSON for C++
+ii  libk5crypto3:amd64                 1.16-2build1                      amd64        MIT Kerberos runtime libraries - Crypto Library
+ii  libkadm5clnt-mit11:amd64           1.16-2build1                      amd64        MIT Kerberos runtime libraries - Administration Clients
+ii  libkadm5srv-mit11:amd64            1.16-2build1                      amd64        MIT Kerberos runtime libraries - KDC and Admin Server
+ii  libkdb5-9:amd64                    1.16-2build1                      amd64        MIT Kerberos runtime libraries - Kerberos database
+ii  libkeyutils1:amd64                 1.5.9-9.2ubuntu1                  amd64        Linux Key Management Utilities (library)
+ii  libklibc                           2.0.4-9ubuntu2                    amd64        minimal libc subset for use with initramfs
+ii  libkmod2:amd64                     24-1ubuntu3                       amd64        libkmod shared library
+ii  libkrb5-26-heimdal:amd64           7.5.0+dfsg-1                      amd64        Heimdal Kerberos - libraries
+ii  libkrb5-3:amd64                    1.16-2build1                      amd64        MIT Kerberos runtime libraries
+ii  libkrb5support0:amd64              1.16-2build1                      amd64        MIT Kerberos runtime libraries - Support library
+ii  libksba8:amd64                     1.3.5-2                           amd64        X.509 and CMS support library
+ii  liblapack-dev:amd64                3.7.1-4ubuntu1                    amd64        Library of linear algebra routines 3 - static version
+ii  liblapack3:amd64                   3.7.1-4ubuntu1                    amd64        Library of linear algebra routines 3 - shared version
+ii  liblcms2-2:amd64                   2.9-1                             amd64        Little CMS 2 color management library
+ii  liblcms2-dev:amd64                 2.9-1                             amd64        Little CMS 2 color management library development headers
+ii  libldap-2.4-2:amd64                2.4.45+dfsg-1ubuntu1              amd64        OpenLDAP libraries
+ii  libldap-common                     2.4.45+dfsg-1ubuntu1              all          OpenLDAP common files for libraries
+ii  libllvm6.0:amd64                   1:6.0-1ubuntu1                    amd64        Modular compiler and toolchain technologies, runtime library
+ii  liblocale-gettext-perl             1.07-3build2                      amd64        module using libc functions for internationalization in Perl
+ii  liblqr-1-0:amd64                   0.4.2-2.1                         amd64        converts plain array images into multi-size representation
+ii  liblqr-1-0-dev:amd64               0.4.2-2.1                         amd64        converts plain array images into multi-size representation (developments files)
+ii  liblsan0:amd64                     8-20180402-1ubuntu1               amd64        LeakSanitizer -- a memory leak detector (runtime)
+ii  libltdl-dev:amd64                  2.4.6-2                           amd64        System independent dlopen wrapper for GNU libtool
+ii  libltdl7:amd64                     2.4.6-2                           amd64        System independent dlopen wrapper for GNU libtool
+ii  liblwres160:amd64                  1:9.11.2.P1-1ubuntu5              amd64        Lightweight Resolver Library used by BIND
+ii  liblz4-1:amd64                     0.0~r131-2ubuntu2                 amd64        Fast LZ compression algorithm library - runtime
+ii  liblzma-dev:amd64                  5.2.2-1.3                         amd64        XZ-format compression library - development files
+ii  liblzma5:amd64                     5.2.2-1.3                         amd64        XZ-format compression library
+ii  liblzo2-2:amd64                    2.08-1.2                          amd64        data compression library
+ii  libmagickcore-6-arch-config:amd64  8:6.9.7.4+dfsg-16ubuntu5          amd64        low-level image manipulation library - architecture header files
+ii  libmagickcore-6-headers            8:6.9.7.4+dfsg-16ubuntu5          all          low-level image manipulation library - header files
+ii  libmagickcore-6.q16-3:amd64        8:6.9.7.4+dfsg-16ubuntu5          amd64        low-level image manipulation library -- quantum depth Q16
+ii  libmagickcore-6.q16-3-extra:amd64  8:6.9.7.4+dfsg-16ubuntu5          amd64        low-level image manipulation library - extra codecs (Q16)
+ii  libmagickcore-6.q16-dev:amd64      8:6.9.7.4+dfsg-16ubuntu5          amd64        low-level image manipulation library - development files (Q16)
+ii  libmagickwand-6-headers            8:6.9.7.4+dfsg-16ubuntu5          all          image manipulation library - headers files
+ii  libmagickwand-6.q16-3:amd64        8:6.9.7.4+dfsg-16ubuntu5          amd64        image manipulation library -- quantum depth Q16
+ii  libmagickwand-6.q16-dev:amd64      8:6.9.7.4+dfsg-16ubuntu5          amd64        image manipulation library - development files (Q16)
+ii  libmagickwand-dev                  8:6.9.7.4+dfsg-16ubuntu5          all          image manipulation library -- dummy package
+ii  libmariadbclient-dev               1:10.1.29-6                       amd64        MariaDB database development files
+ii  libmariadbclient18:amd64           1:10.1.29-6                       amd64        MariaDB database client library
+ii  libmnl0:amd64                      1.0.4-2                           amd64        minimalistic Netlink communication library
+ii  libmount1:amd64                    2.31.1-0.4ubuntu3                 amd64        device mounting library
+ii  libmp3lame0:amd64                  3.100-2                           amd64        MP3 encoding library
+ii  libmpc3:amd64                      1.1.0-1                           amd64        multiple precision complex floating-point library
+ii  libmpdec2:amd64                    2.4.2-1                           amd64        library for decimal floating point arithmetic (runtime library)
+ii  libmpfr6:amd64                     4.0.1-1                           amd64        multiple precision floating-point computation
+ii  libmpx2:amd64                      8-20180402-1ubuntu1               amd64        Intel memory protection extensions (runtime)
+ii  libncurses5:amd64                  6.1-1ubuntu1                      amd64        shared libraries for terminal handling
+ii  libncurses5-dev:amd64              6.1-1ubuntu1                      amd64        developer's libraries for ncurses
+ii  libncursesw5:amd64                 6.1-1ubuntu1                      amd64        shared libraries for terminal handling (wide character support)
+ii  libnettle6:amd64                   3.4-1                             amd64        low level cryptographic library (symmetric and one-way cryptos)
+ii  libnewt0.52:amd64                  0.52.20-1ubuntu1                  amd64        Not Erik's Windowing Toolkit - text mode windowing with slang
+ii  libnghttp2-14:amd64                1.30.0-1                          amd64        library implementing HTTP/2 protocol (shared library)
+ii  libnl-3-200:amd64                  3.2.29-0ubuntu3                   amd64        library for dealing with netlink sockets
+ii  libnl-genl-3-200:amd64             3.2.29-0ubuntu3                   amd64        library for dealing with netlink sockets - generic netlink
+ii  libnpth0:amd64                     1.5-3                             amd64        replacement for GNU Pth using system threads
+ii  libnuma1:amd64                     2.0.11-2.1                        amd64        Libraries for controlling NUMA policy
+ii  libogg0:amd64                      1.3.2-1                           amd64        Ogg bitstream library
+ii  libonig4:amd64                     6.7.0-1                           amd64        regular expressions library
+ii  libopenblas-base:amd64             0.2.20+ds-4                       amd64        Optimized BLAS (linear algebra) library (shared library)
+ii  libopenblas-dev:amd64              0.2.20+ds-4                       amd64        Optimized BLAS (linear algebra) library (development files)
+ii  libopenexr-dev                     2.2.0-11.1ubuntu1                 amd64        development files for the OpenEXR image library
+ii  libopenexr22:amd64                 2.2.0-11.1ubuntu1                 amd64        runtime files for the OpenEXR image library
+ii  libopenjp2-7:amd64                 2.3.0-1                           amd64        JPEG 2000 image compression/decompression library
+ii  libopus0:amd64                     1.1.2-1ubuntu1                    amd64        Opus codec runtime library
+ii  libp11-kit0:amd64                  0.23.9-2                          amd64        library for loading and coordinating access to PKCS#11 modules - runtime
+ii  libpam-modules:amd64               1.1.8-3.6ubuntu1                  amd64        Pluggable Authentication Modules for PAM
+ii  libpam-modules-bin                 1.1.8-3.6ubuntu1                  amd64        Pluggable Authentication Modules for PAM - helper binaries
+ii  libpam-runtime                     1.1.8-3.6ubuntu1                  all          Runtime support for the PAM library
+ii  libpam0g:amd64                     1.1.8-3.6ubuntu1                  amd64        Pluggable Authentication Modules library
+ii  libpango-1.0-0:amd64               1.40.14-1                         amd64        Layout and rendering of internationalized text
+ii  libpango1.0-0:amd64                1.40.14-1                         amd64        Layout and rendering of internationalized text (transitional package)
+ii  libpangocairo-1.0-0:amd64          1.40.14-1                         amd64        Layout and rendering of internationalized text
+ii  libpangoft2-1.0-0:amd64            1.40.14-1                         amd64        Layout and rendering of internationalized text
+ii  libpangox-1.0-0:amd64              0.0.2-5                           amd64        pango library X backend
+ii  libpangoxft-1.0-0:amd64            1.40.14-1                         amd64        Layout and rendering of internationalized text
+ii  libparse-debianchangelog-perl      1.2.0-12                          all          parse Debian changelogs and output them in other formats
+ii  libpcap0.8:amd64                   1.8.1-6ubuntu1                    amd64        system interface for user-level packet capture
+ii  libpciaccess0:amd64                0.13.4-1ubuntu1                   amd64        Generic PCI access library for X
+ii  libpcre16-3:amd64                  2:8.39-9                          amd64        Old Perl 5 Compatible Regular Expression Library - 16 bit runtime files
+ii  libpcre3:amd64                     2:8.39-9                          amd64        Old Perl 5 Compatible Regular Expression Library - runtime files
+ii  libpcre3-dev:amd64                 2:8.39-9                          amd64        Old Perl 5 Compatible Regular Expression Library - development files
+ii  libpcre32-3:amd64                  2:8.39-9                          amd64        Old Perl 5 Compatible Regular Expression Library - 32 bit runtime files
+ii  libpcrecpp0v5:amd64                2:8.39-9                          amd64        Old Perl 5 Compatible Regular Expression Library - C++ runtime files
+ii  libperl5.26:amd64                  5.26.1-5                          amd64        shared Perl library
+ii  libpixman-1-0:amd64                0.34.0-2                          amd64        pixel-manipulation library for X and cairo
+ii  libpixman-1-dev:amd64              0.34.0-2                          amd64        pixel-manipulation library for X and cairo (development files)
+ii  libpng-dev:amd64                   1.6.34-1                          amd64        PNG library - development (version 1.6)
+ii  libpng16-16:amd64                  1.6.34-1                          amd64        PNG library - runtime (version 1.6)
+ii  libpopt0:amd64                     1.16-11                           amd64        lib for parsing cmdline parameters
+ii  libpq-dev                          10.2-1                            amd64        header files for libpq5 (PostgreSQL library)
+ii  libpq5:amd64                       10.2-1                            amd64        PostgreSQL C client library
+ii  libprocps6:amd64                   2:3.3.12-3ubuntu1                 amd64        library for accessing process information from /proc
+ii  libproxy1v5:amd64                  0.4.15-1                          amd64        automatic proxy configuration management library (shared)
+ii  libpsl5:amd64                      0.19.1-5build1                    amd64        Library for Public Suffix List (shared libraries)
+ii  libpthread-stubs0-dev:amd64        0.3-4                             amd64        pthread stubs not provided by native libc, development files
+ii  libpython-stdlib:amd64             2.7.14-4                          amd64        interactive high-level object-oriented language (default python version)
+ii  libpython2.7-minimal:amd64         2.7.14-8                          amd64        Minimal subset of the Python language (version 2.7)
+ii  libpython2.7-stdlib:amd64          2.7.14-8                          amd64        Interactive high-level object-oriented language (standard library, version 2.7)
+ii  libpython3-stdlib:amd64            3.6.4-1                           amd64        interactive high-level object-oriented language (default python3 version)
+ii  libpython3.6:amd64                 3.6.5~rc1-1                       amd64        Shared Python runtime library (version 3.6)
+ii  libpython3.6-minimal:amd64         3.6.5~rc1-1                       amd64        Minimal subset of the Python language (version 3.6)
+ii  libpython3.6-stdlib:amd64          3.6.5~rc1-1                       amd64        Interactive high-level object-oriented language (standard library, version 3.6)
+ii  libquadmath0:amd64                 8-20180402-1ubuntu1               amd64        GCC Quad-Precision Math Library
+ii  libreadline-dev:amd64              7.0-3                             amd64        GNU readline and history libraries, development files
+ii  libreadline7:amd64                 7.0-3                             amd64        GNU readline and history libraries, run-time libraries
+ii  librest-0.7-0:amd64                0.8.0-2                           amd64        REST service access library
+ii  librhash0                          1.3.5-1                           amd64        shared library for hash functions computing
+ii  libroken18-heimdal:amd64           7.5.0+dfsg-1                      amd64        Heimdal Kerberos - roken support library
+ii  librsvg2-2:amd64                   2.40.20-2                         amd64        SAX-based renderer library for SVG files (runtime)
+ii  librsvg2-common:amd64              2.40.20-2                         amd64        SAX-based renderer library for SVG files (extra runtime)
+ii  librsvg2-dev:amd64                 2.40.20-2                         amd64        SAX-based renderer library for SVG files (development)
+ii  librtmp1:amd64                     2.4+20151223.gitfa8646d.1-1       amd64        toolkit for RTMP streams (shared library)
+ii  libruby2.5:amd64                   2.5.1-1ubuntu1                    amd64        Libraries necessary to run Ruby 2.5
+ii  libsasl2-2:amd64                   2.1.27~101-g0780600+dfsg-3ubuntu2 amd64        Cyrus SASL - authentication abstraction library
+ii  libsasl2-dev                       2.1.27~101-g0780600+dfsg-3ubuntu2 amd64        Cyrus SASL - development files for authentication abstraction library
+ii  libsasl2-modules:amd64             2.1.27~101-g0780600+dfsg-3ubuntu2 amd64        Cyrus SASL - pluggable authentication modules
+ii  libsasl2-modules-db:amd64          2.1.27~101-g0780600+dfsg-3ubuntu2 amd64        Cyrus SASL - pluggable authentication modules (DB)
+ii  libseccomp2:amd64                  2.3.1-2.1ubuntu4                  amd64        high level interface to Linux seccomp filter
+ii  libselinux1:amd64                  2.7-2build2                       amd64        SELinux runtime shared libraries
+ii  libselinux1-dev:amd64              2.7-2build2                       amd64        SELinux development headers
+ii  libsemanage-common                 2.7-2build2                       all          Common files for SELinux policy management libraries
+ii  libsemanage1:amd64                 2.7-2build2                       amd64        SELinux policy management library
+ii  libsensors4:amd64                  1:3.4.0-4                         amd64        library to read temperature/voltage/fan sensors
+ii  libsepol1:amd64                    2.7-1                             amd64        SELinux library for manipulating binary security policies
+ii  libsepol1-dev:amd64                2.7-1                             amd64        SELinux binary policy manipulation library and development files
+ii  libserf-1-1:amd64                  1.3.9-6                           amd64        high-performance asynchronous HTTP client library
+ii  libshine3:amd64                    3.1.1-1                           amd64        Fixed-point MP3 encoding library - runtime files
+ii  libsigc++-2.0-0v5:amd64            2.10.0-2                          amd64        type-safe Signal Framework for C++ - runtime
+ii  libsigsegv2:amd64                  2.12-1                            amd64        Library for handling page faults in a portable way
+ii  libslang2:amd64                    2.3.1a-3ubuntu1                   amd64        S-Lang programming library - runtime version
+ii  libsm-dev:amd64                    2:1.2.2-1                         amd64        X11 Session Management library (development headers)
+ii  libsm6:amd64                       2:1.2.2-1                         amd64        X11 Session Management library
+ii  libsmartcols1:amd64                2.31.1-0.4ubuntu3                 amd64        smart column output alignment library
+ii  libsnappy1v5:amd64                 1.1.7-1                           amd64        fast compression/decompression library
+ii  libsoup-gnome2.4-1:amd64           2.62.0-1                          amd64        HTTP library implementation in C -- GNOME support library
+ii  libsoup2.4-1:amd64                 2.62.0-1                          amd64        HTTP library implementation in C -- Shared library
+ii  libsoxr0:amd64                     0.1.2-3                           amd64        High quality 1D sample-rate conversion library
+ii  libspectrum8:amd64                 1.4.1-1                           amd64        ZX Spectrum emulator library - Shared libraries
+ii  libspeex1:amd64                    1.2~rc1.2-1ubuntu1                amd64        The Speex codec runtime library
+ii  libsqlite0                         2.8.17-14fakesync1                amd64        SQLite 2 shared library
+ii  libsqlite0-dev                     2.8.17-14fakesync1                amd64        SQLite 2 development files
+ii  libsqlite3-0:amd64                 3.22.0-1                          amd64        SQLite 3 shared library
+ii  libsqlite3-dev:amd64               3.22.0-1                          amd64        SQLite 3 development files
+ii  libss2:amd64                       1.44.1-1                          amd64        command-line interface parsing library
+ii  libssl1.0.0:amd64                  1.0.2n-1ubuntu5                   amd64        Secure Sockets Layer toolkit - shared libraries
+ii  libssl1.1:amd64                    1.1.0g-2ubuntu3                   amd64        Secure Sockets Layer toolkit - shared libraries
+ii  libstdc++-7-dev:amd64              7.3.0-14ubuntu1                   amd64        GNU Standard C++ Library v3 (development files)
+ii  libstdc++6:amd64                   8-20180402-1ubuntu1               amd64        GNU Standard C++ Library v3
+ii  libsub-name-perl                   0.21-1build1                      amd64        module for assigning a new name to referenced sub
+ii  libsvn1:amd64                      1.9.7-4ubuntu1                    amd64        Shared libraries used by Apache Subversion
+ii  libswresample2:amd64               7:3.4.2-1build1                   amd64        FFmpeg library for audio resampling, rematrixing etc. - runtime files
+ii  libsysfs2:amd64                    2.1.0+repack-4                    amd64        interface library to sysfs
+ii  libsystemd0:amd64                  237-3ubuntu6                      amd64        systemd utility library
+ii  libtasn1-6:amd64                   4.13-2                            amd64        Manage ASN.1 structures (runtime)
+ii  libtext-charwidth-perl             0.04-7.1                          amd64        get display widths of characters on the terminal
+ii  libtext-iconv-perl                 1.7-5build6                       amd64        converts between character sets in Perl
+ii  libtext-wrapi18n-perl              0.06-7.1                          all          internationalized substitute of Text::Wrap
+ii  libthai-data                       0.1.27-2                          all          Data files for Thai language support library
+ii  libthai0:amd64                     0.1.27-2                          amd64        Thai language support library
+ii  libtheora0:amd64                   1.1.1+dfsg.1-14                   amd64        Theora Video Compression Codec
+ii  libtiff-dev                        4.0.9-4ubuntu1                    amd64        Tag Image File Format library (TIFF), development files, current version
+ii  libtiff5:amd64                     4.0.9-4ubuntu1                    amd64        Tag Image File Format (TIFF) library
+ii  libtiff5-dev:amd64                 4.0.9-4ubuntu1                    amd64        Tag Image File Format library (TIFF), development files
+ii  libtiffxx5:amd64                   4.0.9-4ubuntu1                    amd64        Tag Image File Format (TIFF) library -- C++ interface
+ii  libtimedate-perl                   2.3000-2                          all          collection of modules to manipulate date/time information
+ii  libtinfo-dev:amd64                 6.1-1ubuntu1                      amd64        developer's library for the low-level terminfo library
+ii  libtinfo5:amd64                    6.1-1ubuntu1                      amd64        shared low-level terminfo library for terminal handling
+ii  libtirpc1:amd64                    0.2.5-1.2                         amd64        transport-independent RPC library
+ii  libtsan0:amd64                     8-20180402-1ubuntu1               amd64        ThreadSanitizer -- a Valgrind-based detector of data races (runtime)
+ii  libtwolame0:amd64                  0.3.13-3                          amd64        MPEG Audio Layer 2 encoding library
+ii  libubsan0:amd64                    7.3.0-14ubuntu1                   amd64        UBSan -- undefined behaviour sanitizer (runtime)
+ii  libudev1:amd64                     237-3ubuntu6                      amd64        libudev shared library
+ii  libunistring0:amd64                0.9.3-5.2ubuntu1                  amd64        Unicode string library for C
+ii  libunistring2:amd64                0.9.9-0ubuntu1                    amd64        Unicode string library for C
+ii  liburi-perl                        1.73-1                            all          module to manipulate and access URI strings
+ii  libuuid1:amd64                     2.31.1-0.4ubuntu3                 amd64        Universally Unique ID library
+ii  libuv1:amd64                       1.18.0-3                          amd64        asynchronous event notification library - runtime library
+ii  libva-drm2:amd64                   2.1.0-3                           amd64        Video Acceleration (VA) API for Linux -- DRM runtime
+ii  libva-x11-2:amd64                  2.1.0-3                           amd64        Video Acceleration (VA) API for Linux -- X11 runtime
+ii  libva2:amd64                       2.1.0-3                           amd64        Video Acceleration (VA) API for Linux -- runtime
+ii  libvdpau1:amd64                    1.1.1-3ubuntu1                    amd64        Video Decode and Presentation API for Unix (libraries)
+ii  libvorbis0a:amd64                  1.3.5-4.2                         amd64        decoder library for Vorbis General Audio Compression Codec
+ii  libvorbisenc2:amd64                1.3.5-4.2                         amd64        encoder library for Vorbis General Audio Compression Codec
+ii  libvpx-dev:amd64                   1.7.0-3                           amd64        VP8 and VP9 video codec (development files)
+ii  libvpx5:amd64                      1.7.0-3                           amd64        VP8 and VP9 video codec (shared library)
+ii  libwavpack1:amd64                  5.1.0-2ubuntu1                    amd64        audio codec (lossy and lossless) - library
+ii  libwayland-client0:amd64           1.14.0-2                          amd64        wayland compositor infrastructure - client library
+ii  libwayland-cursor0:amd64           1.14.0-2                          amd64        wayland compositor infrastructure - cursor library
+ii  libwayland-egl1-mesa:amd64         18.0.0~rc5-1ubuntu1               amd64        implementation of the Wayland EGL platform -- runtime
+ii  libwayland-server0:amd64           1.14.0-2                          amd64        wayland compositor infrastructure - server library
+ii  libwebp6:amd64                     0.6.1-2                           amd64        Lossy compression of digital photographic images.
+ii  libwebpmux3:amd64                  0.6.1-2                           amd64        Lossy compression of digital photographic images.
+ii  libwind0-heimdal:amd64             7.5.0+dfsg-1                      amd64        Heimdal Kerberos - stringprep implementation
+ii  libwmf-dev                         0.2.8.4-12                        amd64        Windows metafile conversion development
+ii  libwmf0.2-7:amd64                  0.2.8.4-12                        amd64        Windows metafile conversion library
+ii  libwrap0:amd64                     7.6.q-27                          amd64        Wietse Venema's TCP wrappers library
+ii  libx11-6:amd64                     2:1.6.4-3                         amd64        X11 client-side library
+ii  libx11-data                        2:1.6.4-3                         all          X11 client-side library
+ii  libx11-dev:amd64                   2:1.6.4-3                         amd64        X11 client-side library (development headers)
+ii  libx11-xcb1:amd64                  2:1.6.4-3                         amd64        Xlib/XCB interface library
+ii  libx264-152:amd64                  2:0.152.2854+gite9a5903-2         amd64        x264 video coding library
+ii  libx265-146:amd64                  2.6-3                             amd64        H.265/HEVC video stream encoder (shared library)
+ii  libxapian30:amd64                  1.4.5-1                           amd64        Search engine library
+ii  libxau-dev:amd64                   1:1.0.8-1                         amd64        X11 authorisation library (development headers)
+ii  libxau6:amd64                      1:1.0.8-1                         amd64        X11 authorisation library
+ii  libxcb-dri2-0:amd64                1.13-1                            amd64        X C Binding, dri2 extension
+ii  libxcb-dri3-0:amd64                1.13-1                            amd64        X C Binding, dri3 extension
+ii  libxcb-glx0:amd64                  1.13-1                            amd64        X C Binding, glx extension
+ii  libxcb-present0:amd64              1.13-1                            amd64        X C Binding, present extension
+ii  libxcb-render-util0:amd64          0.3.9-1                           amd64        utility libraries for X C Binding -- render-util
+ii  libxcb-render0:amd64               1.13-1                            amd64        X C Binding, render extension
+ii  libxcb-render0-dev:amd64           1.13-1                            amd64        X C Binding, render extension, development files
+ii  libxcb-shm0:amd64                  1.13-1                            amd64        X C Binding, shm extension
+ii  libxcb-shm0-dev:amd64              1.13-1                            amd64        X C Binding, shm extension, development files
+ii  libxcb-sync1:amd64                 1.13-1                            amd64        X C Binding, sync extension
+ii  libxcb-xfixes0:amd64               1.13-1                            amd64        X C Binding, xfixes extension
+ii  libxcb1:amd64                      1.13-1                            amd64        X C Binding
+ii  libxcb1-dev:amd64                  1.13-1                            amd64        X C Binding, development files
+ii  libxcomposite1:amd64               1:0.4.4-2                         amd64        X11 Composite extension library
+ii  libxcursor1:amd64                  1:1.1.15-1                        amd64        X cursor management library
+ii  libxdamage1:amd64                  1:1.1.4-3                         amd64        X11 damaged region extension library
+ii  libxdmcp-dev:amd64                 1:1.1.2-3                         amd64        X11 authorisation library (development headers)
+ii  libxdmcp6:amd64                    1:1.1.2-3                         amd64        X11 Display Manager Control Protocol library
+ii  libxext-dev:amd64                  2:1.3.3-1                         amd64        X11 miscellaneous extensions library (development headers)
+ii  libxext6:amd64                     2:1.3.3-1                         amd64        X11 miscellaneous extension library
+ii  libxfixes3:amd64                   1:5.0.3-1                         amd64        X11 miscellaneous 'fixes' extension library
+ii  libxft2:amd64                      2.3.2-1                           amd64        FreeType-based font drawing library for X
+ii  libxi6:amd64                       2:1.7.9-1                         amd64        X11 Input extension library
+ii  libxinerama1:amd64                 2:1.1.3-1                         amd64        X11 Xinerama extension library
+ii  libxkbcommon0:amd64                0.8.0-1                           amd64        library interface to the XKB compiler - shared library
+ii  libxml2:amd64                      2.9.4+dfsg1-6.1ubuntu1            amd64        GNOME XML library
+ii  libxml2-dev:amd64                  2.9.4+dfsg1-6.1ubuntu1            amd64        Development files for the GNOME XML library
+ii  libxpm-dev:amd64                   1:3.5.12-1                        amd64        X11 pixmap library (development headers)
+ii  libxpm4:amd64                      1:3.5.12-1                        amd64        X11 pixmap library
+ii  libxrandr2:amd64                   2:1.5.1-1                         amd64        X11 RandR extension library
+ii  libxrender-dev:amd64               1:0.9.10-1                        amd64        X Rendering Extension client library (development files)
+ii  libxrender1:amd64                  1:0.9.10-1                        amd64        X Rendering Extension client library
+ii  libxshmfence1:amd64                1.2-1                             amd64        X shared memory fences - shared library
+ii  libxslt1-dev:amd64                 1.1.29-5                          amd64        XSLT 1.0 processing library - development kit
+ii  libxslt1.1:amd64                   1.1.29-5                          amd64        XSLT 1.0 processing library - runtime library
+ii  libxt-dev:amd64                    1:1.1.5-1                         amd64        X11 toolkit intrinsics library (development headers)
+ii  libxt6:amd64                       1:1.1.5-1                         amd64        X11 toolkit intrinsics library
+ii  libxvidcore4:amd64                 2:1.3.5-1                         amd64        Open source MPEG-4 video codec (library)
+ii  libxxf86vm1:amd64                  1:1.1.4-1                         amd64        X11 XFree86 video mode extension library
+ii  libyaml-0-2:amd64                  0.1.7-2ubuntu3                    amd64        Fast YAML 1.1 parser and emitter library
+ii  libyaml-dev:amd64                  0.1.7-2ubuntu3                    amd64        Fast YAML 1.1 parser and emitter library (development)
+ii  libzvbi-common                     0.2.35-13                         all          Vertical Blanking Interval decoder (VBI) - common files
+ii  libzvbi0:amd64                     0.2.35-13                         amd64        Vertical Blanking Interval decoder (VBI) - runtime files
+ii  linux-base                         4.5ubuntu1                        all          Linux image base package
+ii  linux-libc-dev:amd64               4.15.0-13.14                      amd64        Linux Kernel Headers for development
+ii  locales                            2.27-0ubuntu2                     all          GNU C Library: National Language (locale) data [support]
+ii  login                              1:4.5-1ubuntu1                    amd64        system login tools
+ii  lsb-base                           9.20170808ubuntu1                 all          Linux Standard Base init script functionality
+ii  lsb-release                        9.20170808ubuntu1                 all          Linux Standard Base version reporting utility
+ii  lsof                               4.89+dfsg-0.1                     amd64        Utility to list open files
+ii  lzma                               9.22-2ubuntu2                     amd64        Compression and decompression in the LZMA format - command line utility
+ii  m4                                 1.4.18-1                          amd64        macro processing language
+ii  make                               4.1-9.1                           amd64        utility for directing compilation
+ii  manpages                           4.15-1                            all          Manual pages about using a GNU/Linux system
+ii  manpages-dev                       4.15-1                            all          Manual pages about using GNU/Linux for development
+ii  mawk                               1.3.3-17ubuntu2                   amd64        a pattern scanning and text processing language
+ii  mercurial                          4.5.2-0ubuntu2                    amd64        easy-to-use, scalable distributed version control system
+ii  mercurial-common                   4.5.2-0ubuntu2                    all          easy-to-use, scalable distributed version control system (common files)
+ii  mime-support                       3.60ubuntu1                       all          MIME files 'mime.types' & 'mailcap', and support programs
+ii  mount                              2.31.1-0.4ubuntu3                 amd64        tools for mounting and manipulating filesystems
+ii  multiarch-support                  2.27-0ubuntu2                     amd64        Transitional package to ensure multiarch compatibility
+ii  mysql-common                       5.8+1.0.4                         all          MySQL database common files, e.g. /etc/mysql/my.cnf
+ii  ncurses-base                       6.1-1ubuntu1                      all          basic terminal type definitions
+ii  ncurses-bin                        6.1-1ubuntu1                      amd64        terminal-related programs and man pages
+ii  netbase                            5.4                               all          Basic TCP/IP networking system
+ii  netcat-openbsd                     1.187-1                           amd64        TCP/IP swiss army knife
+ii  netplan.io                         0.34.1                            amd64        YAML network configuration abstraction for various backends
+ii  nplan                              0.34.1                            all          YAML network configuration abstraction - transitional package
+ii  ocaml-base-nox                     4.05.0-10ubuntu1                  amd64        Runtime system for OCaml bytecode executables (no X)
+ii  openssh-client                     1:7.6p1-4                         amd64        secure shell (SSH) client, for secure access to remote machines
+ii  openssh-server                     1:7.6p1-4                         amd64        secure shell (SSH) server, for secure access from remote machines
+ii  openssh-sftp-server                1:7.6p1-4                         amd64        secure shell (SSH) sftp server module, for SFTP access from remote machines
+ii  openssl                            1.1.0g-2ubuntu3                   amd64        Secure Sockets Layer toolkit - cryptographic utility
+ii  passwd                             1:4.5-1ubuntu1                    amd64        change and administer password and group data
+ii  patch                              2.7.6-1                           amd64        Apply a diff file to an original
+ii  perl                               5.26.1-5                          amd64        Larry Wall's Practical Extraction and Report Language
+ii  perl-base                          5.26.1-5                          amd64        minimal Perl system
+ii  perl-modules-5.26                  5.26.1-5                          all          Core Perl modules
+ii  pinentry-curses                    1.1.0-1                           amd64        curses-based PIN or pass-phrase entry dialog for GnuPG
+ii  pkg-config                         0.29.1-0ubuntu2                   amd64        manage compile and link flags for libraries
+ii  procps                             2:3.3.12-3ubuntu1                 amd64        /proc file system utilities
+ii  psmisc                             23.1-1                            amd64        utilities that use the proc file system
+ii  python                             2.7.14-4                          amd64        interactive high-level object-oriented language (default version)
+ii  python-bzrlib                      2.7.0+bzr6622-10                  amd64        distributed version control system - python library
+ii  python-configobj                   5.0.6-2                           all          simple but powerful config file reader and writer for Python 2
+ii  python-minimal                     2.7.14-4                          amd64        minimal subset of the Python language (default version)
+ii  python-six                         1.11.0-2                          all          Python 2 and 3 compatibility library (Python 2 interface)
+ii  python2.7                          2.7.14-8                          amd64        Interactive high-level object-oriented language (version 2.7)
+ii  python2.7-minimal                  2.7.14-8                          amd64        Minimal subset of the Python language (version 2.7)
+ii  python3                            3.6.4-1                           amd64        interactive high-level object-oriented language (default python3 version)
+ii  python3-distutils                  3.6.5~rc1-1                       all          distutils package for Python 3.x
+ii  python3-lib2to3                    3.6.5~rc1-1                       all          Interactive high-level object-oriented language (2to3, version 3.6)
+ii  python3-minimal                    3.6.4-1                           amd64        minimal subset of the Python language (default python3 version)
+ii  python3-yaml                       3.12-1build2                      amd64        YAML parser and emitter for Python3
+ii  python3.6                          3.6.5~rc1-1                       amd64        Interactive high-level object-oriented language (version 3.6)
+ii  python3.6-minimal                  3.6.5~rc1-1                       amd64        Minimal subset of the Python language (version 3.6)
+ii  quota                              4.04-2                            amd64        disk quota management tools
+ii  rake                               12.3.1-1                          all          ruby make-like utility
+ii  readline-common                    7.0-3                             all          GNU readline and history libraries, common files
+ii  rsync                              3.1.2-2.1ubuntu1                  amd64        fast, versatile, remote (and local) file-copying tool
+ii  ruby                               1:2.5.1                           amd64        Interpreter of object-oriented scripting language Ruby (default version)
+ii  ruby-did-you-mean                  1.0.0-2                           all          smart error messages for Ruby > 2.3
+ii  ruby-minitest                      5.10.3-1                          all          Ruby test tools supporting TDD, BDD, mocking, and benchmarking
+ii  ruby-net-telnet                    0.1.1-2                           all          telnet client library
+ii  ruby-power-assert                  0.3.0-1                           all          library showing values of variables and method calls in an expression
+ii  ruby-test-unit                     3.2.5-1                           all          unit testing framework for Ruby
+ii  ruby2.5                            2.5.1-1ubuntu1                    amd64        Interpreter of object-oriented scripting language Ruby
+ii  rubygems-integration               1.11                              all          integration of Debian Ruby packages with Rubygems
+ii  sed                                4.4-2                             amd64        GNU stream editor for filtering/transforming text
+ii  sensible-utils                     0.0.12                            all          Utilities for sensible alternative selection
+ii  shared-mime-info                   1.9-2                             amd64        FreeDesktop.org shared MIME database and spec
+ii  sshfs                              2.8-1                             amd64        filesystem client based on SSH File Transfer Protocol
+ii  strace                             4.19-1ubuntu2                     amd64        System call tracer
+ii  subversion                         1.9.7-4ubuntu1                    amd64        Advanced version control system
+ii  sudo                               1.8.21p2-3ubuntu1                 amd64        Provide limited super user privileges to specific users
+ii  sysstat                            11.6.1-1                          amd64        system performance tools for Linux
+ii  systemd                            237-3ubuntu6                      amd64        system and service manager
+ii  systemd-sysv                       237-3ubuntu6                      amd64        system and service manager - SysV links
+ii  sysvinit-utils                     2.88dsf-59.10ubuntu1              amd64        System-V-like utilities
+ii  tar                                1.29b-2                           amd64        GNU version of the tar archiving utility
+ii  tasksel                            3.34ubuntu11                      all          tool for selecting tasks for installation on Debian systems
+ii  tasksel-data                       3.34ubuntu11                      all          official tasks used for installation of Debian systems
+ii  tcpdump                            4.9.2-3                           amd64        command-line network traffic analyzer
+ii  traceroute                         1:2.1.0-2                         amd64        Traces the route taken by packets over an IPv4/IPv6 network
+ii  ttf-dejavu-core                    2.37-1                            all          transitional dummy package
+ii  tzdata                             2018d-1                           all          time zone and daylight-saving time data
+ii  ubuntu-advantage-tools             17                                all          management tools for Ubuntu Advantage
+ii  ubuntu-keyring                     2018.02.28                        all          GnuPG keys of the Ubuntu archive
+ii  ubuntu-minimal                     1.414                             amd64        Minimal core of Ubuntu
+ii  ubuntu-mono                        16.10+18.04.20180328-0ubuntu1     all          Ubuntu Mono Icon theme
+ii  ucf                                3.0038                            all          Update Configuration File(s): preserve user changes to config files
+ii  udev                               237-3ubuntu6                      amd64        /dev/ and hotplug management daemon
+ii  unzip                              6.0-21ubuntu1                     amd64        De-archiver for .zip files
+ii  util-linux                         2.31.1-0.4ubuntu3                 amd64        miscellaneous system utilities
+ii  uuid-dev:amd64                     2.31.1-0.4ubuntu3                 amd64        Universally Unique ID library - headers and static libraries
+ii  vim-common                         2:8.0.1401-1ubuntu3               all          Vi IMproved - Common files
+ii  vim-tiny                           2:8.0.1401-1ubuntu3               amd64        Vi IMproved - enhanced vi editor - compact version
+ii  wget                               1.19.4-1ubuntu2                   amd64        retrieves files from the web
+ii  whiptail                           0.52.20-1ubuntu1                  amd64        Displays user-friendly dialog boxes from shell scripts
+ii  x11-common                         1:7.7+19ubuntu5                   all          X Window System (X.Org) infrastructure
+ii  x11proto-core-dev                  7.0.31-1                          all          X11 core wire protocol and auxiliary headers
+ii  x11proto-input-dev                 2.3.2-1                           all          X11 Input extension wire protocol
+ii  x11proto-kb-dev                    1.0.7-1                           all          X11 XKB extension wire protocol
+ii  x11proto-render-dev                2:0.11.1-2                        all          X11 Render extension wire protocol
+ii  x11proto-xext-dev                  7.3.0-1                           all          X11 various extension wire protocol
+ii  xkb-data                           2.23.1-1ubuntu1                   all          X Keyboard Extension (XKB) configuration data
+ii  xorg-sgml-doctools                 1:1.11-1                          all          Common tools for building X.Org SGML documentation
+ii  xtrans-dev                         1.3.5-1                           all          X transport library (development files)
+ii  xxd                                2:8.0.1401-1ubuntu3               amd64        tool to make (or reverse) a hex dump
+ii  xz-utils                           5.2.2-1.3                         amd64        XZ-format compression utilities
+ii  zip                                3.0-11build1                      amd64        Archiver for .zip files
+ii  zlib1g:amd64                       1:1.2.11.dfsg-0ubuntu2            amd64        compression library - runtime
+ii  zlib1g-dev:amd64                   1:1.2.11.dfsg-0ubuntu2            amd64        compression library - development


### PR DESCRIPTION
Fix few warnings and namely map 14.04 -> 18.04 package names.

The package mapping may not be necessarily correct, it was done solely based on the following package listings:

  - https://packages.ubuntu.com/trusty/allpackages
  - https://packages.ubuntu.com/bionic/allpackages

... but at least the build process succeeds.