### PR TITLE
Add gssapi module for libsasl2 to allow for Kerberos authentication via SASL

### DIFF
--- a/packages/cflinuxfs3
+++ b/packages/cflinuxfs3
@@ -75,6 +75,7 @@ libreadline6-dev
 librtmp-dev
 libsasl2-dev
 libsasl2-modules
+libsasl2-modules-gssapi-mit
 libselinux1-dev
 libsqlite0-dev
 libsqlite3-dev


### PR DESCRIPTION
`libsasl2` and `libsasl2-modules` are already included by default. Including `libsasl2-modules-gssapi-mit` as well would allow applications that rely upon SASL to perform authentication to also use Kerberos-type authentication without any additional installation.

This addresses #4. 