### PR TITLE
nokogiri want to libxml

### DIFF
--- a/packages/cflinuxfs3
+++ b/packages/cflinuxfs3
@@ -117,3 +117,4 @@ ureadahead
 uuid-dev
 wget
 zip
+libxml2-dev


### PR DESCRIPTION
Hi team!
nokogiri is one of the populer ruby gems.
it is to need  `libxml2-dev`.
I hope you will install the package