### PR TITLE
Use UID for vcap user in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ RUN useradd -u 2000 -mU -s /bin/bash vcap && \
   chown vcap:vcap /home/vcap/app && \
   ln -s /home/vcap/app /app
 
-USER vcap
+USER 2000


### PR DESCRIPTION
Hello, Eirini team here,

When Eirini tries to run applications, which are based on `cflinuxfs3`, with non-root user, we get the following error in Kubernetes:
```
PodSecurityPolicy set to runAsNonRoot, container has runAsNonRoot and image has non-numeric user (vcap), cannot verify user is non-root
```

This PR changes the way the user is set in the docker image in order to fix the issue.

cc @alex-slynko