### PR TITLE
Leave existing and empty Ubuntu Bionic FHS dirs alone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,6 @@ RUN echo "debconf debconf/frontend select noninteractive" | debconf-set-selectio
   apt-get -y $package_args install $packages && \
   apt-get clean && \
   find /usr/share/doc/*/* ! -name copyright | xargs rm -rf && \
-  rm -rf \
-    /usr/share/man/* /usr/share/info/* \
-    /usr/share/groff/* /usr/share/lintian/* /usr/share/linda/* \
-    /var/lib/apt/lists/* /tmp/*
 
 RUN echo 'LANG="en_US.UTF-8"' > /etc/default/locale && \
   echo "$locales" | grep -f - /usr/share/i18n/SUPPORTED | cut -d " " -f 1 | xargs locale-gen && \


### PR DESCRIPTION
## TL;DR

There's no good reason to remove these directories and doing so interferes with the clean configuration of .deb packages that buildpacks (or applications using the `apt-buildpack`) install. 

### The problem
To see the problem, first run `docker run -it --rm ubuntu:bionic bash` then 
```
apt update
apt-get install default-jre-headless -y
java -version
```

You will see the installation proceed without a hitch, and the `java` CLI will be in the path and functional.

However, if you run `docker run -it --rm cloudfoundry/cflinuxfs3:latest bash`, and then the same commands, you will see that the final configuration of the installed packages is thrown off by the missing `/usr/share/man/man1` directory.

<details>
<summary>[[EXPAND]] dpkg-configure errors out due to missing directories</summary>

```
Setting up openjdk-11-jre-headless:amd64 (11.0.11+9-0ubuntu2~18.04) ...
update-alternatives: using /usr/lib/jvm/java-11-openjdk-amd64/bin/java to provide /usr/bin/java (java) in auto mode
update-alternatives: error: error creating symbolic link '/usr/share/man/man1/java.1.gz.dpkg-tmp': No such file or directory
dpkg: error processing package openjdk-11-jre-headless:amd64 (--configure):
 installed openjdk-11-jre-headless:amd64 package post-installation script subprocess returned error exit status 2
dpkg: dependency problems prevent configuration of default-jre-headless:
 default-jre-headless depends on openjdk-11-jre-headless; however:
  Package openjdk-11-jre-headless:amd64 is not configured yet.

dpkg: error processing package default-jre-headless (--configure):
 dependency problems - leaving unconfigured
dpkg: dependency problems prevent configuration of openjdk-11-jre:amd64:
 openjdk-11-jre:amd64 depends on openjdk-11-jre-headless (= 11.0.11+9-0ubuntu2~18.04); however:
  Package openjdk-11-jre-headless:amd64 is not configured yet.

dpkg: error processing package openjdk-11-jre:amd64 (--configure):
 dependency problems - leaving unconfigured
dpkg: dependency problems prevent configuration of ca-certificates-java:
 ca-certificates-java depends on openjdk-11-jre-headless | java8-runtime-headless; however:
  Package openjdk-11-jre-headless:amd64 is not configured yet.
  Package java8-runtime-headless is not installed.
  Package default-jre-headless which provides java8-runtime-headless is not configured yet.
  Package openjdk-11-jre-headless:amd64 which provides java8-runtime-headless is not configured yet.

dpkg: error processing package ca-certificates-java (--configure):
 dependency problems - leaving unconfigured
dpkg: dependency problems prevent configuration of default-jre:
 default-jre depends on default-jre-headless (= 2:1.11-68ubuntu1~18.04.1); however:
  Package default-jre-headless is not configured yet.
 default-jre depends on openjdk-11-jre; however:
  Package openjdk-11-jre:amd64 is not configured yet.

dpkg: error processing package default-jre (--configure):
 dependency problems - leaving unconfigured
Processing triggers for libc-bin (2.27-3ubuntu1.4) ...
Processing triggers for ca-certificates (20210119~18.04.2) ...
Updating certificates in /etc/ssl/certs...
0 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.
Processing triggers for hicolor-icon-theme (0.17-2) ...
Processing triggers for fontconfig (2.12.6-0ubuntu2) ...
Processing triggers for mime-support (3.60ubuntu1) ...
Errors were encountered while processing:
 openjdk-11-jre-headless:amd64
 default-jre-headless
 openjdk-11-jre:amd64
 ca-certificates-java
 default-jre
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

</details>

This results in a non-functional installation, and `java` won't even be in the path.

### Why is this there?

Quoting from a DM with @sclevine about the origin of this line in the CF Slack:

> **mogul  2:44 PM**
> Hey there! Hope you're well... I am doing some git repo archaeology on cflinuxfs3.  Can you tell me why this line removes everything under /usr/share/man?
> https://github.com/cloudfoundry/cflinuxfs3/blame/f3eec66870384b5b27731a97070522a2f9e193de/Dockerfile#L17
> 
> **slevine  2:45 PM**
> hey!
> probably size
> 
> **mogul  2:45 PM**
> OK, so not due to a security concern or anything?
> 
> **slevine  2:45 PM**
> 🤷‍♂️ 
> I think it was cargo-culted from cflinuxfs2
> but I don’t imagine so

I checked what this line actually removes that is present in Ubuntu Bionic. It's 102 total paths... 
```
# find /usr/share/man/* /usr/share/info/*     /usr/share/groff/* /usr/share/lintian/* /usr/share/linda/*     /var/lib/apt/lists/* /tmp/* | wc -l 
find: '/usr/share/groff/*': No such file or directory
find: '/usr/share/linda/*': No such file or directory
find: '/var/lib/apt/lists/*': No such file or directory
find: '/tmp/*': No such file or directory
102
```

...and 68 of them are directories, which packages might want to drop stuff into.

<details>
<summary>[[EXPAND]] List of removed directories</summary>

```
root@6171aa754160:/# find /usr/share/man/* /usr/share/info/*     /usr/share/groff/* /usr/share/lintian/* /usr/share/linda/*     /var/lib/apt/lists/* /tmp/* -type d | wc -l
find: '/usr/share/groff/*': No such file or directory
find: '/usr/share/linda/*': No such file or directory
find: '/var/lib/apt/lists/*': No such file or directory
find: '/tmp/*': No such file or directory
68
root@6171aa754160:/# find /usr/share/man/* /usr/share/info/*     /usr/share/groff/* /usr/share/lintian/* /usr/share/linda/*     /var/lib/apt/lists/* /tmp/* -type d
/usr/share/man/cs
/usr/share/man/cs/man1
/usr/share/man/cs/man5
/usr/share/man/cs/man8
/usr/share/man/da
/usr/share/man/da/man1
/usr/share/man/da/man5
/usr/share/man/da/man8
/usr/share/man/de
/usr/share/man/de/man1
/usr/share/man/de/man5
/usr/share/man/de/man8
/usr/share/man/es
/usr/share/man/es/man1
/usr/share/man/es/man5
/usr/share/man/es/man8
/usr/share/man/fi
/usr/share/man/fi/man1
/usr/share/man/fr
/usr/share/man/fr/man1
/usr/share/man/fr/man5
/usr/share/man/fr/man8
/usr/share/man/hu
/usr/share/man/hu/man1
/usr/share/man/id
/usr/share/man/id/man1
/usr/share/man/it
/usr/share/man/it/man1
/usr/share/man/it/man5
/usr/share/man/it/man8
/usr/share/man/ja
/usr/share/man/ja/man1
/usr/share/man/ja/man5
/usr/share/man/ja/man8
/usr/share/man/ko
/usr/share/man/ko/man1
/usr/share/man/man1
/usr/share/man/man3
/usr/share/man/man5
/usr/share/man/man7
/usr/share/man/man8
/usr/share/man/nl
/usr/share/man/nl/man5
/usr/share/man/nl/man8
/usr/share/man/pl
/usr/share/man/pl/man1
/usr/share/man/pl/man5
/usr/share/man/pl/man8
/usr/share/man/pt
/usr/share/man/pt/man5
/usr/share/man/pt/man8
/usr/share/man/ru
/usr/share/man/ru/man1
/usr/share/man/ru/man5
/usr/share/man/ru/man8
/usr/share/man/sv
/usr/share/man/sv/man1
/usr/share/man/sv/man5
/usr/share/man/sv/man8
/usr/share/man/tr
/usr/share/man/tr/man1
/usr/share/man/zh_CN
/usr/share/man/zh_CN/man1
/usr/share/man/zh_CN/man5
/usr/share/man/zh_CN/man8
/usr/share/man/zh_TW
/usr/share/man/zh_TW/man1
find: '/usr/share/groff/*': No such file or directory
/usr/share/lintian/overrides
find: '/usr/share/linda/*': No such file or directory
find: '/var/lib/apt/lists/*': No such file or directory
find: '/tmp/*': No such file or directory
```

</details>

Note that a given path might be assumed present by many different packages! For example, here are the 28 base packages that expect `/usr/share/man/man1` to be present:

```
# dpkg -S /usr/share/man/man1
util-linux, tar, sensible-utils, sed, procps, perl-base, passwd, ncurses-bin, mawk, login, libc-bin, init-system-helpers, hostname, gzip, grep, gpgv, findutils, e2fsprogs, dpkg, diffutils, debianutils, debconf, dash, coreutils, bzip2, bsdutils, bash, apt: /usr/share/man/man1
```

So by removing these directories and their content, cflinuxfs3 is undermining the integrity of files managed by the Ubuntu packaging system.

What's in there accounts for 872K total:
```
# du -shc /usr/share/man/* /usr/share/info/*     /usr/share/groff/* /usr/share/lintian/* /usr/share/linda/*     /var/lib/apt/lists/* /tmp/* | tail -1
du: cannot access '/usr/share/groff/*': No such file or directory
du: cannot access '/usr/share/linda/*': No such file or directory
du: cannot access '/var/lib/apt/lists/*': No such file or directory
du: cannot access '/tmp/*': No such file or directory
872K    total
```

That's a negligible amount, but perhaps these directories are removed to save space from manual pages required/installed by buildpack-supplied packages later, as @sclevine guessed? If that's the reason, then there's a better way to do that, and it's already in place:
```
# cat /etc/dpkg/dpkg.cfg.d/excludes 
# Drop all man pages
path-exclude=/usr/share/man/*

# Drop all translations
path-exclude=/usr/share/locale/*/LC_MESSAGES/*.mo

# Drop all documentation ...
path-exclude=/usr/share/doc/*

# ... except copyright files ...
path-include=/usr/share/doc/*/copyright

# ... and Debian changelogs
path-include=/usr/share/doc/*/changelog.Debian.*
```

### The solution
This line that has no discernable benefit, and causes at least some active friction and frustration for users of Cloud Foundry ([namely my team](https://github.com/GSA/datagov-deploy/issues/2917#issuecomment-941639709))! The PR removes it.
