### PR TITLE
remove password auth & root ssh access

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ RUN echo "debconf debconf/frontend select noninteractive" | debconf-set-selectio
     /usr/share/groff/* /usr/share/lintian/* /usr/share/linda/* \
     /var/lib/apt/lists/* /tmp/*
 
+RUN sed -i s/#PermitRootLogin.*/PermitRootLogin\ no/ /etc/ssh/sshd_config && \
+  sed -i s/#PasswordAuthentication.*/PasswordAuthentication\ no/ /etc/ssh/sshd_config
+
 RUN echo 'LANG="en_US.UTF-8"' > /etc/default/locale && \
   echo "$locales" | grep -f - /usr/share/i18n/SUPPORTED | cut -d " " -f 1 | xargs locale-gen && \
   dpkg-reconfigure -fnoninteractive -pcritical locales tzdata libc6


### PR DESCRIPTION
Explicitly set password auth and root login off in SSH daemon config
to improve security.

Resolves #26 